### PR TITLE
PMM-4874 remove old items from glossary and hide some which are not r…

### DIFF
--- a/source/glossary-terminology.rst
+++ b/source/glossary-terminology.rst
@@ -25,31 +25,6 @@ Terminology Reference
 	 Queries retention
 	    :option:`QUERIES_RETENTION`
 
-.. _Data-Source-Name:
-
-`Data Source Name <Data-Source-Name>`_
---------------------------------------------------------------------------------
-
-      A database server attribute found on the :ref:`QAN <QAN>` page. It informs how
-      :ref:`PMM <PMM>` connects to the selected database.
-
-
-.. only:: showhidden
-
-   .. _Default-ports:
-
-   `Default ports <default-ports>`_
-   --------------------------------------------------------------------------------
-
-      See :ref:`Ports <Ports>`.
-
-.. _DSN:
-
-`DSN <DSN>`_
---------------------------------------------------------------------------------
-
-      See :ref:`Data Source Name <Data-Source-Name>`
-
 .. _Grand-Total-Time:
 
 `Grand Total Time <Grand-Total-Time>`_
@@ -107,21 +82,6 @@ Terminology Reference
 	 Passing parameters to a monitoring service
 	    :ref:`pmm.pmm-admin.monitoring-service.pass-parameter`
 
-.. only:: showhidden
-
-	.. _Orchestrator:
-
-	`Orchestrator <Orchestrator>`_
-	--------------------------------------------------------------------------------
-
-	      The topology manager for |mysql|. By default it is disabled for the
-	      :ref:`PMM-Server`. To enable it, set the :option:`ORCHESTRATOR_ENABLED`.
-
-	      .. seealso::
-
-		 Docker container: Enabling orchestrator
-		    :option:`ORCHESTRATOR_ENABLED`
-
 .. _PMM:
 
 `PMM <PMM>`_
@@ -137,21 +97,23 @@ Terminology Reference
       A program which changes the configuration of the :ref:`PMM-Client`. See
       detailed documentation in the :ref:`pmm-admin` section.
 
-.. _PMM-annotation:
+.. only:: showhidden
 
-`PMM annotation <PMM-annotation>`_
---------------------------------------------------------------------------------
+	.. _PMM-annotation:
 
-   A feature of |pmm-server| which adds a special mark to all
-   dashboards and signifies an important event in your
-   application. Annotations are added on the |pmm-client| by using
-   the |pmm-admin.annotate| command.
+	`PMM annotation <PMM-annotation>`_
+	--------------------------------------------------------------------------------
 
-   .. seealso::
+	   A feature of |pmm-server| which adds a special mark to all
+	   dashboards and signifies an important event in your
+	   application. Annotations are added on the |pmm-client| by using
+	   the |pmm-admin.annotate| command.
 
-	 |grafana| Documentation: Annotations
+	   .. seealso::
 
-	    http://docs.grafana.org/reference/annotations/
+		 |grafana| Documentation: Annotations
+
+		    http://docs.grafana.org/reference/annotations/
 
 .. _PMM-Client:
 
@@ -221,23 +183,25 @@ Terminology Reference
 
       .. include:: .res/code/docker.exec.it.pmm-server.head.txt
 
-.. _PMM-user-permissions-for-AWS:
+.. only:: showhidden
 
-`PMM user permissions for AWS <PMM-user-permissions-for-AWS>`_
---------------------------------------------------------------------------------
+	.. _PMM-user-permissions-for-AWS:
 
-      When creating a `IAM user
-      <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SettingUp.html#CHAP_SettingUp.IAM>`_
-      for |amazon-rds| DB instance that you intend to monitor in PMM, you need to set all
-      required permissions properly. For this, you may copy the following |JSON| for your
-      IAM user:
+	`PMM user permissions for AWS <PMM-user-permissions-for-AWS>`_
+	--------------------------------------------------------------------------------
 
-      .. include:: .res/code/aws.iam-user.permission.txt
+	      When creating a `IAM user
+	      <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SettingUp.html#CHAP_SettingUp.IAM>`_
+	      for |amazon-rds| DB instance that you intend to monitor in PMM, you need to set all
+	      required permissions properly. For this, you may copy the following |JSON| for your
+	      IAM user:
 
-      .. seealso::
+	      .. include:: .res/code/aws.iam-user.permission.txt
 
-	 Creating an IAM user
-	    :ref:`pmm.amazon-rds.iam-user.creating`
+	      .. seealso::
+
+		 Creating an IAM user
+		    :ref:`pmm.amazon-rds.iam-user.creating`
 
 .. _PMM-Version:
 
@@ -257,39 +221,6 @@ Terminology Reference
 
 	     :ref:`PMM Server Version <PMM-Server-Version>`
 
-.. only:: showhidden
-
-	.. _Ports:
-
-	`Ports <Ports>`_
-	--------------------------------------------------------------------------------
-
-	      The following ports must be open to enable communication between
-	      the :ref:`PMM Server <PMM-Server>` and :ref:`PMM clients <PMM-Client>`.
-
-	      |pmm-server| should keep ports 80 or 443 ports open for
-	      computers where |pmm-client| is installed to access the |pmm|
-	      web interface.
-
-	      42000
-		 For |pmm| to collect genenal system metrics.
-	      42001
-		 This port is used by a service which collects query performance data
-		 and makes it available to |qan|.
-	      42002
-		 For |pmm| to collect |mysql| server metrics.
-	      42003
-		 For |pmm| to collect |mongodb| server metrics.
-	      42004
-		 For |pmm| to collect |proxysql| server metrics.
-
-	      .. seealso::
-
-		 Setting up a firewall on |centos|
-		    https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-7
-		 Setting up a firewall on |ubuntu|
-		    https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-with-ufw-on-ubuntu-16-04
-
 .. _QAN:
 
 `QAN <QAN>`_
@@ -297,13 +228,15 @@ Terminology Reference
 
       See :ref:`Query Analytics (QAN) <Query-Analytics>`
 
-.. _Query-Abstract:
+.. only:: showhidden
 
-`Query Abstract <Query-Abstract>`_
---------------------------------------------------------------------------------
+	.. _Query-Abstract:
 
-      Query pattern with placeholders. This term appears in
-      :ref:`QAN <Query-Analytics>` as an attribute of queries.
+	`Query Abstract <Query-Abstract>`_
+	--------------------------------------------------------------------------------
+
+	      Query pattern with placeholders. This term appears in
+	      :ref:`QAN <Query-Analytics>` as an attribute of queries.
 
 .. _Query-Analytics:
 
@@ -313,19 +246,21 @@ Terminology Reference
       Component of :ref:`PMM-Server` that enables you to analyze
       |mysql| query performance over periods of time.
 
-.. _Query-Fingerprint:
+.. only:: showhidden
 
-`Query Fingerprint <Query-Fingerprint>`_
---------------------------------------------------------------------------------
+	.. _Query-Fingerprint:
 
-      See :ref:`Query Abstract <Query-Abstract>`
+	`Query Fingerprint <Query-Fingerprint>`_
+	--------------------------------------------------------------------------------
 
-.. _Query-ID:
+	      See :ref:`Query Abstract <Query-Abstract>`
+	
+	.. _Query-ID:
 
-`Query ID <Query-ID>`_
---------------------------------------------------------------------------------
+	`Query ID <Query-ID>`_
+	--------------------------------------------------------------------------------
 
-      A :ref:`query fingerprint <Query-Fingerprint>` which groups similar queries.
+	      A :ref:`query fingerprint <Query-Fingerprint>` which groups similar queries.
 
 .. _Query-Load:
 
@@ -382,25 +317,27 @@ Terminology Reference
       A predefined time period (see :ref:`Quick ranges <Quick-ranges>`), such as 1 hour, or a
       range of dates that :ref:`QAN <QAN>` uses to collects metrics.
 
-.. _Telemetry:
+.. only:: showhidden
 
-`Telemetry <Telemetry>`_
---------------------------------------------------------------------------------
+	.. _Telemetry:
 
-      |percona| may collect some statistics about the machine where |pmm| is running.
+	`Telemetry <Telemetry>`_
+	--------------------------------------------------------------------------------
 
-      This statistics includes the following information:
+	      |percona| may collect some statistics about the machine where |pmm| is running.
 
-      - |pmm-server| unique ID
-      - |pmm| version
-      - The name and version of the operating system, |ami| or virtual appliance
-      - |mysql| version
-      - |perl| version
+	      This statistics includes the following information:
 
-      You may disable telemetry :ref:`by passing an additional parameter
-      <pmm.docker.additional-option>` to |docker|.
+	      - |pmm-server| unique ID
+	      - |pmm| version
+	      - The name and version of the operating system, |ami| or virtual appliance
+	      - |mysql| version
+	      - |perl| version
 
-      .. include:: .res/code/docker.run.disable-telemetry.txt
+	      You may disable telemetry :ref:`by passing an additional parameter
+	      <pmm.docker.additional-option>` to |docker|.
+
+	      .. include:: .res/code/docker.run.disable-telemetry.txt
 
 .. _Version:
 


### PR DESCRIPTION
…eady

Removed: DSN and Data Source Name, Ports and Orchestrator (last 2 were already hidden)
Hidden: Annotations, Telemetry, PMM user permissions to AWS, Query Abstract and Query Fingerprint with the related stuff.