### PR TITLE
PMM-5253 fix server url parameter presentation in pmm client config doc

### DIFF
--- a/source/install/client-install-apt.rst
+++ b/source/install/client-install-apt.rst
@@ -48,7 +48,7 @@ procedure. |tip.run-all.root|:
 
 #. Once PMM Client is installed, run the ``pmm-admin config`` command with your PMM Server IP address to register your Node within the Server::
 
-     pmm-admin config --server-insecure-tls --server-url=<IP Address>:443
+     pmm-admin config --server-insecure-tls --server-url=https://admin:admin@<IP Address>:443
 
    You should see the following::
 

--- a/source/install/client-install-yum.rst
+++ b/source/install/client-install-yum.rst
@@ -37,7 +37,7 @@ To install the |pmm-client| package, complete the following procedure. |tip.run-
 
 #. Once PMM Client is installed, run the ``pmm-admin config`` command with your PMM Server IP address to register your Node within the Server::
 
-     pmm-admin config --server-insecure-tls --server-url=<IP Address>:443
+     pmm-admin config --server-insecure-tls --server-url=https://admin:admin@<IP Address>:443
 
    You should see the following::
 


### PR DESCRIPTION
Fis for incorrect (outdated)  documentation in our Installation Manual 

![image](https://user-images.githubusercontent.com/25495422/71924503-d1543180-3197-11ea-9a5d-b3a5c4eab008.png)

This will be replaced by 
--server-url=https://admin:admin@<IP Address\>:443

Because for now, PMM requires HTTPS and username/password  (admin/admin  is the default ) 