### PR TITLE
Version picker test

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Percona Monitoring and Management Documentation
-site_url: https://new.percona.com/doc/percona-monitoring-and-management/2.x
+#site_url: https://new.percona.com/doc/percona-monitoring-and-management/2.x
 repo_name: percona/pmm-doc
 repo_url: https://github.com/percona/pmm-doc
 edit_uri: edit/master/docs/

--- a/theme/main.html
+++ b/theme/main.html
@@ -109,7 +109,7 @@
 {#### PMM1/PMM2 version switcher #}
 {% macro version_menu() %}
 <h3>
-  <a href="{{ url_root }}">Contents</a>
+  <a href="{{ url_root|url }}">Table of Contents</a>
 </h3>
 <style>
   .select-wrapper {
@@ -135,7 +135,6 @@
   window.pmm2DocRedirect = () => {
     const docLink = document.querySelector("#another-doc-version-link");
     let newLink = "{{ url_root|url }}/index.html";
-//    let newLink = "{{ base_url|url }}/{{ config.extra.major }}/index.html";
     if (docLink) {
       if (docLink.href) {
         newLink = docLink.href;

--- a/theme/main.html
+++ b/theme/main.html
@@ -134,7 +134,8 @@
 <script>
   window.pmm2DocRedirect = () => {
     const docLink = document.querySelector("#another-doc-version-link");
-    let newLink = "{{ base_url|url }}/{{ config.extra.major }}/index.html";
+    let newLink = "{{ url_root|url }}/index.html";
+//    let newLink = "{{ base_url|url }}/{{ config.extra.major }}/index.html";
     if (docLink) {
       if (docLink.href) {
         newLink = docLink.href;
@@ -144,7 +145,7 @@
   };
   window.pmmDocRedirect = () => {
     const docLink = document.querySelector("#another-doc-version-link");
-    let newLink = "{{ base_url|url }}/index.html";
+    let newLink = "{{ url_root|url }}/../index.html";
     if (docLink) {
       if (docLink.dataset.location) {
         newLink = docLink.dataset.location;
@@ -159,8 +160,8 @@
     <span class="glyphicon glyphicon-chevron-down"></span>
   </div>
   <ul class="select-hidden" id="custom_select_list">
-    <li><a class="custom-select__option" href="javascript:window.pmmDocRedirect()">PMM1</a></li>
-    <li><a class="custom-select__option" href="javascript:window.pmm2DocRedirect()">PMM2</a></li>
+    <li><a class="custom-select__option" href="javascript:window.pmmDocRedirect()">PMM 1</a></li>
+    <li><a class="custom-select__option" href="javascript:window.pmm2DocRedirect()">PMM 2</a></li>
   </ul>
 </section>
 {% endmacro %}

--- a/theme/main.html
+++ b/theme/main.html
@@ -134,7 +134,7 @@
 <script>
   window.pmm2DocRedirect = () => {
     const docLink = document.querySelector("#another-doc-version-link");
-    let newLink = "{{ base_url }}/{{ config.extra.major }}/index.html";
+    let newLink = "{{ base_url|url }}/{{ config.extra.major }}/index.html";
     if (docLink) {
       if (docLink.href) {
         newLink = docLink.href;
@@ -144,7 +144,7 @@
   };
   window.pmmDocRedirect = () => {
     const docLink = document.querySelector("#another-doc-version-link");
-    let newLink = "{{ base_url }}/index.html";
+    let newLink = "{{ base_url|url }}/index.html";
     if (docLink) {
       if (docLink.dataset.location) {
         newLink = docLink.dataset.location;


### PR DESCRIPTION
Tests to make version picker switch to same domain
e.g. 
2->1 (test)
new.percona.com/doc/percona-monitoring-and-management/2.x/index.html -> new.percona.com/doc/percona-monitoring-and-management/index.html
2->1 (live)
www.percona.com/doc/percona-monitoring-and-management/2.x/index.html -> www.percona.com/doc/percona-monitoring-and-management/index.html

(1->2 doesn't work like this yet as URLs are hard-coded into PMM1's code for version switcher.)