### PR TITLE
Tweak paths for version switcher

### DIFF
--- a/theme/main.html
+++ b/theme/main.html
@@ -197,7 +197,7 @@
 <script>
     window.pmm2DocRedirect = () => {
         const docLink = document.querySelector("#another-doc-version-link");
-        let newLink = "{{ url_root }}/";
+        let newLink = "{{ url_root }}";
         if (docLink) {
             if (docLink.href) {
                 newLink = docLink.href;
@@ -207,7 +207,7 @@
     };
     window.pmmDocRedirect = () => {
         const docLink = document.querySelector("#another-doc-version-link");
-        let newLink = "{{ url_root }}/../";
+        let newLink = "{{ url_root }}../";
         if (docLink) {
             if (docLink.dataset.location) {
                 newLink = docLink.dataset.location;


### PR DESCRIPTION
Web host is VERY strict about paths, not allowing even a stray slash in the URL. 