### PR TITLE
Invalid information for ProxySQL monitoring

### DIFF
--- a/docs/setting-up/client/proxysql.md
+++ b/docs/setting-up/client/proxysql.md
@@ -9,7 +9,7 @@ to enable ProxySQL performance metrics monitoring.
 pmm-admin add proxysql --username=admin --password=admin
 ```
 
-where username and password are credentials for the admin interface of the monitored ProxySQL instance. 
+where username and password are credentials for the administration interface of the monitored ProxySQL instance. 
 Additionally, two positional arguments can be appended to the command line flags: a service name to be used
 by PMM, and a service address. If not specified, they are substituted
 automatically as `<node>-proxysql` and `127.0.0.1:6032`.

--- a/docs/setting-up/client/proxysql.md
+++ b/docs/setting-up/client/proxysql.md
@@ -9,11 +9,10 @@ to enable ProxySQL performance metrics monitoring.
 pmm-admin add proxysql --username=admin --password=admin
 ```
 
-where username and password are credentials for the monitored MongoDB access,
-which will be used locally on the database host. Additionally, two positional
-arguments can be appended to the command line flags: a service name to be used
+where username and password are credentials for the admin interface of the monitored ProxySQL instance. 
+Additionally, two positional arguments can be appended to the command line flags: a service name to be used
 by PMM, and a service address. If not specified, they are substituted
-automatically as `<node>-proxysql` and `127.0.0.1:3306`.
+automatically as `<node>-proxysql` and `127.0.0.1:6032`.
 
 The output of this command may look as follows:
 


### PR DESCRIPTION
Documentation mentions MongoDB, uses the MySQL port and also talks about local database instances