### PR TITLE
Adding an example alert template to documentation

### DIFF
--- a/docs/using/alerting.md
+++ b/docs/using/alerting.md
@@ -101,7 +101,8 @@ This page has four tabs.
 2. Click {{ icon.plussquare }} *Add*.
 
 3. Enter a template in the *Alert Rule Template* text box.
-```
+
+    ```
     ---
     templates:
         - name: mysql_too_many_connections
@@ -130,7 +131,7 @@ This page has four tabs.
                 VALUE = {{ $value }}
                 LABELS: {{ $labels }}
             summary: MySQL too many connections (instance {{ $labels.instance }})
-```
+    ```
 
     ![](../_images/PMM_Integrated_Alerting_Alert_Rule_Templates_Add_Form.jpg)
 

--- a/docs/using/alerting.md
+++ b/docs/using/alerting.md
@@ -101,6 +101,36 @@ This page has four tabs.
 2. Click {{ icon.plussquare }} *Add*.
 
 3. Enter a template in the *Alert Rule Template* text box.
+```
+    ---
+    templates:
+        - name: mysql_too_many_connections
+          version: 1
+          summary: MySQL connections in use
+          tiers: [anonymous, registered]
+          expr: |-
+            max_over_time(mysql_global_status_threads_connected[5m]) / ignoring (job)
+            mysql_global_variables_max_connections
+            * 100
+            > [[ .threshold ]]
+          params:
+            - name: threshold
+              summary: A percentage from configured maximum
+              unit: '%'
+              type: float
+              range: [0, 100]
+              value: 80
+          for: 5m
+          severity: warning
+          labels:
+            foo: bar
+          annotations:
+            description: |-
+                More than [[ .threshold ]]% of MySQL connections are in use on {{ $labels.instance }}
+                VALUE = {{ $value }}
+                LABELS: {{ $labels }}
+            summary: MySQL too many connections (instance {{ $labels.instance }})
+```
 
     ![](../_images/PMM_Integrated_Alerting_Alert_Rule_Templates_Add_Form.jpg)
 


### PR DESCRIPTION
There is no easy way to create an alert template as we provide no guide so until you can view/clone existing templates we need at least something on the website to help users create a template.  This doesn't even scratch the surface though of how to actually create an alert on something unique nor a guide to what the possible variables/substitutions are.