### PR TITLE
Removed non-supported mongod_exporter flags

### DIFF
--- a/docs/details/commands/pmm-admin.md
+++ b/docs/details/commands/pmm-admin.md
@@ -299,15 +299,6 @@ PMM communicates with the PMM Server via a PMM agent process.
     `--tls-skip-verify`
     :  Skip TLS certificates validation.
 
-    `--tls-certificate-key-file=PATHTOCERT`
-    : Path to TLS certificate file.
-
-    `--tls-certificate-key-file=IFPASSWORDTOCERTISSET`
-    : Password for TLS certificate file.
-
-    `--tls-ca-file=PATHTOCACERT`
-    : Path to certificate authority file.
-
     `--metrics-mode=mode`
     : Metrics flow mode for agents node-exporter. Allowed values:
         - `auto`: chosen by server (default)


### PR DESCRIPTION
These arguments seem to be a leftover from PMM v1 in the documentation, as they are not supported anymore:

```
agustin@tp-support03 ~ $ pmm-admin add mongodb --tls-certificate-key-file=./file.pem
pmm-admin: error: unknown long flag '--tls-certificate-key-file', try --help
```

```
agustin@tp-support03 ~ $ pmm-admin add mongodb --tls-ca-file=./file.pem
pmm-admin: error: unknown long flag '--tls-ca-file', try --help
```
