### PR TITLE
Remove equal sign from sed in DBaaS setup

### DIFF
--- a/docs/setting-up/server/dbaas.md
+++ b/docs/setting-up/server/dbaas.md
@@ -93,7 +93,7 @@ alias kubectl='minikube kubectl --'
     curl -sSf -m 30 https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/v1.7.0/deploy/bundle.yaml \
     | kubectl apply -f -
     curl -sSf -m 30 https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/v1.7.0/deploy/secrets.yaml \
-    | sed "s/pmmserver:.*=/pmmserver: ${PMM_PASS}/g" \
+    | sed "s/pmmserver:.*/pmmserver: ${PMM_PASS}/g" \
     | kubectl apply -f -
 
     # Install the PSMDB operator


### PR DESCRIPTION
The equal sign makes sed not work. The password is not included in the secret and user fails to start pxc clusters.
Now, it's removed.