### PR TITLE
RHEL/CentOS 6 only has support up to version 2.12

### DIFF
--- a/docs/setting-up/client/index.md
+++ b/docs/setting-up/client/index.md
@@ -21,7 +21,7 @@ You will need root access on the database host where you install PMM Client (eit
 
 PMM Client should run on any modern Red Hat or Debian-based 64-bit Linux distribution, but is only tested on:
 
-- RHEL/CentOS 6, 7, 8
+- RHEL/CentOS 6 (up to version 2.12), 7, 8
 - Debian 8, 9, 10
 - Ubuntu 16.04, 18.04, 20.04
 


### PR DESCRIPTION
Changing the doc to show the real version supporting for RHEL/CentOS 6