### PR TITLE
Index page links

### DIFF
--- a/docs/details/dashboards/index.md
+++ b/docs/details/dashboards/index.md
@@ -1,10 +1,4 @@
-# Dashboards Index
-
----
-
-[TOC]
-
----
+# Dashboards
 
 ## Insight
 

--- a/docs/details/index.md
+++ b/docs/details/index.md
@@ -1,12 +1,14 @@
-# Details: Overview
+# Details
 
 - [Architecture](architecture.md): high-level architecture and main components.
 
 - [Dashboards reference](dashboards/index.md): A complete list of dashboards by category, with screenshots
 
-- Commands
-    - [pmm-admin](commands/pmm-admin.md): A manual page for the PMM administration tool
-    - [pmm-agent](commands/pmm-agent.md): A manual page for the PMM Client agent program
+- [User interface components](interface.md): Descriptions of the main menus and icons
+
+- Commands:
+    - [pmm-admin](commands/pmm-admin.md): The manual page for the PMM administration tool
+    - [pmm-agent](commands/pmm-agent.md): The manual page for the PMM Client agent program
 
 - [API](api.md): How to access the Swagger API
 

--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -2,12 +2,6 @@
 
 The *PMM Settings* page lets you configure a number of PMM options.
 
----
-
-[TOC]
-
----
-
 Open the *PMM Settings* page with one of:
 
 - the main menu: choose *PMM-->PMM Settings*

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,4 +1,4 @@
-# How to: Overview
+# How to
 
 - [Configure](configure.md) via the PMM Settings page
 - [Upgrade](upgrade.md) PMM Server via the user interface

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,10 +1,10 @@
 # How to: Overview
 
-- [Configure](configure.md)
-    - The [PMM Settings page](configure.md)
-- [Secure](secure.md)
-    - Securing your PMM installation
-- [Upgrade](upgrade.md)
-    - Upgrading PMM Server via the user interface
-- [Optimize](optimize.md)
-    - Improving PMM performance
+- [Configure](configure.md) via the PMM Settings page
+- [Upgrade](upgrade.md) PMM Server via the user interface
+- [Secure](secure.md) your PMM installation
+- [Optimize](optimize.md) the performance of your PMM installation
+- [Annotate](annotate.md) charts to mark significant events
+- [Render dashboard images](render-dashboard-images.md) to save or share
+- [Troubleshoot](troubleshoot.md):
+	- [Integrated Alerting](troubleshoot.md#integrated-alerting)

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -1,11 +1,5 @@
 # Troubleshoot
 
----
-
-[TOC]
-
----
-
 ## Integrated Alerting
 
 ### No {{icon.bell}} Integrated Alerting icon

--- a/docs/setting-up/client/index.md
+++ b/docs/setting-up/client/index.md
@@ -1,9 +1,5 @@
 # Setting up PMM Clients
 
-[TOC]
-
----
-
 PMM Client is a package of agents and exporters installed on the host you wish to monitor.
 
 Before installing, know your PMM Server's IP address and make sure that it is accessible.

--- a/docs/setting-up/index.md
+++ b/docs/setting-up/index.md
@@ -1,16 +1,15 @@
 # Setting up
 
 - [PMM Server](server/index.md) as a:
-
 	- [Docker](server/docker.md) container
 	- [Virtual appliance](server/virtual-appliance.md) based on our OVA/OVF image
 	- [Amazon AWS EC2](server/aws.md) instance via the Amazon AWS Marketplace
 
-- [PMM Client](client/index.md)
-- [PMM Client as a Docker container](client/docker.md)
+- [PMM Client](client/index.md):
+	- [on Linux](client/index.md#installing-pmm-client-with-your-linux-package-manager)
+	- [as a Docker container](client/docker.md)
 
-- Adding PMM Clients:
-
+- Monitoring for:
 	- [MySQL](client/mysql.md)
 	- [Percona Server for MySQL](client/percona-server.md)
 	- [MongoDB](client/mongodb.md)

--- a/docs/setting-up/index.md
+++ b/docs/setting-up/index.md
@@ -1,28 +1,23 @@
 # Setting up
 
-[PMM Server](server/index.md) as a:
+- [PMM Server](server/index.md) as a:
 
-- [Docker](server/docker.md) container
-- [Virtual appliance](server/virtual-appliance.md) based on our OVA/OVF image
-- [Amazon AWS EC2](server/aws.md) instance via the Amazon AWS Marketplace
+	- [Docker](server/docker.md) container
+	- [Virtual appliance](server/virtual-appliance.md) based on our OVA/OVF image
+	- [Amazon AWS EC2](server/aws.md) instance via the Amazon AWS Marketplace
 
----
+- [PMM Client](client/index.md)
+- [PMM Client as a Docker container](client/docker.md)
 
-PMM Client as a:
+- Adding PMM Clients:
 
-- [Docker container](client/docker.md)
-
----
-
-[PMM Clients](client/index.md) on:
-
-- [MySQL](client/mysql.md)
-- [Percona Server for MySQL](client/percona-server.md)
-- [MongoDB](client/mongodb.md)
-- [PostgreSQL](client/postgresql.md)
-- [ProxySQL](client/proxysql.md)
-- [Amazon RDS](client/aws.md)
-- [Microsoft Azure](client/azure.md)
-- [Linux](client/linux.md)
-- [External services](client/external.md)
-- [HAProxy](client/haproxy.md)
+	- [MySQL](client/mysql.md)
+	- [Percona Server for MySQL](client/percona-server.md)
+	- [MongoDB](client/mongodb.md)
+	- [PostgreSQL](client/postgresql.md)
+	- [ProxySQL](client/proxysql.md)
+	- [Amazon RDS](client/aws.md)
+	- [Microsoft Azure](client/azure.md)
+	- [Linux](client/linux.md)
+	- [External services](client/external.md)
+	- [HAProxy](client/haproxy.md)

--- a/docs/setting-up/index.md
+++ b/docs/setting-up/index.md
@@ -1,4 +1,4 @@
-# Setting up: Overview
+# Setting up
 
 [PMM Server](server/index.md) as a:
 
@@ -8,7 +8,9 @@
 
 ---
 
-[PMM Client as a Docker container](client/docker.md)
+PMM Client as a:
+
+- [Docker container](client/docker.md)
 
 ---
 

--- a/docs/setting-up/server/docker.md
+++ b/docs/setting-up/server/docker.md
@@ -1,11 +1,5 @@
 # Docker
 
----
-
-[TOC]
-
----
-
 Percona maintain a Docker image for PMM Server at <https://hub.docker.com/r/percona/pmm-server>.
 
 The Docker tags used here are for the latest version of PMM 2 ({{release}}) but you can specify any available tag to use the corresponding version of PMM Server.
@@ -72,7 +66,7 @@ The Docker tags used here are for the latest version of PMM 2 ({{release}}) but 
     ```
 
     With `jq`:
-    
+
     ```sh
     docker inspect pmm-data | jq '.[].Mounts[].Destination'
     docker inspect pmm-server | jq '.[].Mounts[].Destination'

--- a/docs/using/alerting.md
+++ b/docs/using/alerting.md
@@ -5,14 +5,7 @@
 !!! alert alert-warning "Warning"
     Integrated Alerting is a technical preview and is subject to change.
 
-
 **To activate *Integrated Alerting***, select *PMM-->PMM Settings-->Advanced Settings*, turn on *Integrated Alerting* and click *Apply changes*.
-
----
-
-[TOC]
-
----
 
 ## Definitions
 

--- a/docs/using/index.md
+++ b/docs/using/index.md
@@ -1,27 +1,17 @@
-# Using: Overview
+# Using
 
----
+- [User Interface](interface.md)
 
-[User Interface](interface.md)
+	- Using the web-based user interface
+	- Finding dashboards
+	- Rendering dashboard images
+	- Viewing graph details
+	- Annotating events
 
-- Using the web-based user interface
-- Finding dashboards
-- Rendering dashboard images
-- Viewing graph details
-- Annotating events
+- [Integrated alerting](alerting.md)
 
----
+- [Query Analytics](query-analytics.md), a specialized dashboard for detailed query analysis
 
-[Integrated alerting](alerting.md)
+- [Percona Enterprise Platform](platform/index.md)
 
----
-
-[Query Analytics](query-analytics.md)
-
-- Specialized dashboard for detailed query analysis
-
----
-
-[Percona Enterprise Platform](platform/index.md)
-
-- [Security Threat Tool](platform/security-threat-tool.md): Enabling and seeing the results of database security checks
+	- [Security Threat Tool](platform/security-threat-tool.md): Enabling and seeing the results of database security checks

--- a/docs/using/platform/security-threat-tool.md
+++ b/docs/using/platform/security-threat-tool.md
@@ -2,12 +2,6 @@
 
 The Security Threat Tool runs regular checks against connected databases, alerting you if any servers pose a potential security threat.
 
----
-
-[TOC]
-
----
-
 All checks run on the PMM Client side. Results are sent to PMM Server where a summary count is shown on the *Home Dashboard*, with details in the *PMM Database Checks* dashboard.
 
 Checks are automatically downloaded from Percona Enterprise Platform and run every 24 hours. (This period is not configurable.)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ plugins:
   - search
   - git-revision-date
   - bootstrap-tables
+  - section-index
   - macros:
         include_yaml:
           - 'variables.yml' # Use in markdown as '{{ VAR }}'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
       - details/glossary.md
   - faq.md
   - Release Notes:
+      - release-notes/index.md
       - release-notes/2.15.0.md
       - release-notes/2.14.0.md
       - release-notes/2.13.0.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ plantuml-markdown
 mkdocs-git-revision-date-plugin
 mkdocs-material-extensions
 mkdocs-bootstrap-tables-plugin
+mkdocs-section-index
 mike


### PR DESCRIPTION
New plugin adds links to section headings (MkDocs doesn't do this by default). This recreates the behaviour of other PMM doc sites and the old Sphinx-based PMM2/PMM1 docs.
Section landing pages are also updated with commentary on subsections.