### PR TITLE
Test mkdocs admonition alternatives

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,7 @@ With PMM, you can:
 
 PMM is efficient, quick to set up and easy to use. It runs in cloud, on-prem, or across hybrid platforms. It is supported by [Percona's legendary expertise][PERCONA_SERVICES] in open source databases, and by a [vibrant developer and user community][PMM_FORUM].
 
-<div class="alert alert-info">
-Try the live demo: <a href='https://pmmdemo.percona.com/' target='_blank'>pmmdemo.percona.com</a>
-</div>
+> Try the live demo: <a href='https://pmmdemo.percona.com/' target='_blank'>pmmdemo.percona.com</a>
 
 ## How it works
 
@@ -44,7 +42,7 @@ PMM Client runs on every database host or node you want to monitor. The client c
 
 ## Setting up
 
-!!! alert alert-info "Quickstart installation <{{ extra.quickstart }}>"
+> [**Quickstart installation**][PMM_QUICKSTART]
 
 PMM Server communicates with clients, receives metrics data and presents it in a web-based user interface. PMM Server can run as: [a Docker container](setting-up/server/docker.md), an [virtual machine](setting-up/server/virtual-appliance.md), or as an [Amazon AWS EC2 instance](setting-up/server/aws.md). (Learn more about [setting up PMM Server](setting-up/server/index.md).)
 
@@ -58,3 +56,4 @@ PMM Client runs on all hosts you want to monitor according to the type of system
 
 [PERCONA_SERVICES]: https://www.percona.com/services
 [PMM_FORUM]: https://www.percona.com/forums/questions-discussions/percona-monitoring-and-management
+[PMM_QUICKSTART]: https://www.percona.com/software/pmm/quickstart

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,9 @@
 
 **Percona Monitoring and Management (PMM) is a free, open-source monitoring tool for MySQL, PostgreSQL, MongoDB, and ProxySQL, and the servers they run on.** PMM helps you improve the performance of databases, simplify their management, and strengthen their security.
 
-!!! alert alert-success "This documentation is for the latest release: [PMM {{release}}](release-notes/{{release}}.md)"
+<div class="alert alert-success">
+This documentation is for the latest release: <a href="release-notes/{{release}}.html">PMM {{release}}</a>
+</div>
 
 With PMM, you can:
 
@@ -11,9 +13,11 @@ With PMM, you can:
 - Drill-down and discover the cause of inefficiencies, anticipate performance issues, or troubleshoot existing ones
 - Watch for potential security issues and remedy them
 
-PMM is efficient, quick to set up and easy to use. It runs in cloud, on-prem, or across hybrid platforms. It is supported by [Percona's legendary expertise](https://www.percona.com/services) in open source databases, and by a [vibrant developer and user community](https://www.percona.com/forums/questions-discussions/percona-monitoring-and-management).
+PMM is efficient, quick to set up and easy to use. It runs in cloud, on-prem, or across hybrid platforms. It is supported by [Percona's legendary expertise][PERCONA_SERVICES] in open source databases, and by a [vibrant developer and user community][PMM_FORUM].
 
-!!! alert alert-info "Try the live demo: <a href='https://pmmdemo.percona.com/' target='_blank'>pmmdemo.percona.com</a>"
+<div class="alert alert-info">
+Try the live demo: <a href='https://pmmdemo.percona.com/' target='_blank'>pmmdemo.percona.com</a>
+</div>
 
 ## How it works
 
@@ -50,3 +54,7 @@ PMM Client runs on all hosts you want to monitor according to the type of system
 
 ```plantuml format="svg_object" width="90%" height="90%" source="_resources/diagrams/Map.puml"
 ```
+
+
+[PERCONA_SERVICES]: https://www.percona.com/services
+[PMM_FORUM]: https://www.percona.com/forums/questions-discussions/percona-monitoring-and-management

--- a/variables.yml
+++ b/variables.yml
@@ -6,8 +6,6 @@ release_date: 2021-03-01
 
 # Miscellaneous values
 extra:
-  # Link to quickstart landing page
-  quickstart: 'https://www.percona.com/software/pmm/quickstart'
   # Link to AWS Marketplace for PMM Server
   server_aws: 'https://aws.amazon.com/marketplace/pp/B077J7FYGX'
   # Code block includes


### PR DESCRIPTION
Begin making source less mkdocs-y. Use standard GH admonitions where possible, augmented with standard HTML bootstrap ones where needed.