### PR TITLE
Fixed package name for contrib

### DIFF
--- a/docs/setting-up/client/postgresql.md
+++ b/docs/setting-up/client/postgresql.md
@@ -8,7 +8,7 @@ For specific details on supported platforms and versions, see
 To monitor PostgreSQL queries, you must install a database extension. There are two choices:
 
 - `pg_stat_monitor`, a new extension created by Percona, based on `pg_stat_statements` and compatible with it.
-- `pg_stat_statements`, the original extension created by PostgreSQL, part of the `postgres-contrib` package available on Linux.
+- `pg_stat_statements`, the original extension created by PostgreSQL, part of the `postgresql-contrib` package available on Linux.
 
 (We recommend using only one. If you use both, you will get duplicate metrics.)
 


### PR DESCRIPTION
The package name seems incorrect.
Debian
```sh
$ apt list postgresql-contrib postgres-contrib
Listing... Done
postgresql-contrib/stable 11+200+deb10u4 all
N: There is 1 additional version. Please use the '-a' switch to see it
```
CentOS 7
```sh
$ yum info postgresql-contrib postgres-contrib                                                                                                                                       
Loaded plugins: changelog, product-id, search-disabled-repos, versionlock
Excluding 2 updates due to versionlock (use "yum versionlock status" to show them)
Available Packages
Name        : postgresql-contrib
Arch        : x86_64
Version     : 9.2.24
Release     : 4.el7_8
Size        : 552 k
Repo        : base/7/x86_64
Summary     : Extension modules distributed with PostgreSQL
URL         : http://www.postgresql.org/
License     : PostgreSQL
Description : The postgresql-contrib package contains various extension modules that are
            : included in the PostgreSQL distribution.
```