### PR TITLE
Use custom PXC operator

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -6,7 +6,7 @@ release_date: 2021-03-18
 
 # Setting Up/Server/DBaaS operator versions
 op:
-  pxc_vers: 'v1.7.0'
+  pxc_vers: 'K8SPXC-668-CUSTOM'
   psmdb_vers: 'v1.7.0'
 
 # Miscellaneous values


### PR DESCRIPTION
We had issues with disconnecting during ongoing queries. Operators team created custom build based on v1.7.0 but with the fix for the issues we were having.