### PR TITLE
Separate pdf config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We use [MkDocs](https://www.mkdocs.org/) to convert [Markdown](https://daringfir
 
 The documentation source files are in the `docs` directory. (Other files in this repo are explained in [Directories and files](#directories-and-files).)
 
-We use different branches for two major PMM versions:
+The two major PMM versions are kept in separate branches:
 
 - `main` is for PMM 2.x (latest)
 - `1.x` is for PMM 1.x
@@ -39,9 +39,9 @@ If you'd like to have a local copy of PMM documentation, or are thinking about c
 3. Change directory to `pmm-doc`
 4. Use [our Docker image](https://hub.docker.com/repository/docker/perconalab/pmm-doc-md) to *build the documentation*:
 
-	```sh
-	docker run --rm -v $(pwd):/docs perconalab/pmm-doc-md mkdocs build -t material
-	```
+    ```sh
+    docker run --rm -v $(pwd):/docs perconalab/pmm-doc-md mkdocs build -t material
+    ```
 
 5. Find the `site` directory, open `index.html` in a browser to view the first page of documentation.
 
@@ -59,15 +59,15 @@ If you prefer not to use Docker, you'll have to install MkDocs and all its depen
 
 2. Install MkDocs and required extensions:
 
-	```sh
-	pip install -r requirements.txt
-	```
+    ```sh
+    pip install -r requirements.txt
+    ```
 
 3. Build the site with your choice of theme (choose one of `mkdocs`, `readthedocs`, `material`, `gitbook` or `bootstrap4`):
 
-	```sh
-	mkdocs build -t material
-	```
+    ```sh
+    mkdocs build -t material
+    ```
 
 4. Open `site/index.html`
 
@@ -81,46 +81,47 @@ And view the site at <http://localhost:8000>
 
 ## PDF
 
-To generate a PDF version of the documentation:
+You can create a PDF version of the documentation.
 
-1. Edit `mkdocs.yml` and comment out the `section-index` plugin.
+1. If for a release, edit `mkdoc-pdf.yml` and change:
 
-2. Build the PDF.
+    - The release number in `plugins.with-pdf.output_path`
+    - The release number and date in `plugins.with-pdf.cover_subtitle`
 
-	With Docker:
+2. If using Docker:
 
-	```sh
-	docker run --rm -v $(pwd):/docs -e ENABLE_PDF_EXPORT=1 perconalab/pmm-doc-md mkdocs build -t material
-	```
+    ```sh
+    docker run --rm -v $(pwd):/docs -e ENABLE_PDF_EXPORT=1 perconalab/pmm-doc-md mkdocs build -f mkdocs-pdf.yml
+    ```
 
-	Without:
+    If not:
 
-	```sh
-	ENABLE_PDF_EXPORT=1 mkdocs build -t material
-	```
+    ```sh
+    ENABLE_PDF_EXPORT=1 mkdocs build -f mkdocs-pdf.yml
+    ```
 
-3. The PDF is in `site/_pdf`.
+2. The PDF is in `site/_pdf`.
 
 ## Directories and files
 
 - `mkdocs.yml`: Main MkDocs configuration file
 - `nav.yml`: Navigation (`nav`) element in separate file defining table of contents
 - `docs`:
-	- `*.md`: Markdown files
-	- `_images/*`: Images
-	- `css`: Styling
-	- `js`: JavaScript files
+    - `*.md`: Markdown files
+    - `_images/*`: Images
+    - `css`: Styling
+    - `js`: JavaScript files
 - `_resources`:
-	- `bin`
-	    - `glossary.tsv`: Export from a spreadsheet of glossary entries.
-    	- `make_glossary.pl`: Script to write Markdown page from `glossary.tsv`.
-    	- `grafana-dashboards-descriptions.py`: Script to extract dashboard descriptions from <https://github.com/percona/grafana-dashboards/>.
-		- `plantuml`: Wrapper script for running PlantUML.
-	- `diagrams`:
-		- `*.puml`: [PlantUML](https://plantuml.com) diagrams (see comments inside each).
-		- `plantuml_styles.uml`: Global style for PlantUML diagrams.
-	- `templates`: Stylesheet for PDF output (used by [mkdocs-with-pdf](https://github.com/orzih/mkdocs-with-pdf) extension).
-	- `theme`: MkDocs template for HTML intended for publishing on percona.com.
+    - `bin`
+        - `glossary.tsv`: Export from a spreadsheet of glossary entries.
+        - `make_glossary.pl`: Script to write Markdown page from `glossary.tsv`.
+        - `grafana-dashboards-descriptions.py`: Script to extract dashboard descriptions from <https://github.com/percona/grafana-dashboards/>.
+        - `plantuml`: Wrapper script for running PlantUML.
+    - `diagrams`:
+        - `*.puml`: [PlantUML](https://plantuml.com) diagrams (see comments inside each).
+        - `plantuml_styles.uml`: Global style for PlantUML diagrams.
+    - `templates`: Stylesheet for PDF output (used by [mkdocs-with-pdf](https://github.com/orzih/mkdocs-with-pdf) extension).
+    - `theme`: MkDocs template for HTML intended for publishing on percona.com.
 - `requirements.txt`: Python package dependencies.
 - `variables.yml`: Values used throughout the Markdown, including the current PMM version/release number.
 - `.spelling`: Words regarded as correct by `mdspell` (See [Spelling and grammar](#spelling-and-grammar).)
@@ -138,23 +139,23 @@ With this, a [GitHub actions](https://github.com/percona/pmm-doc/actions) workfl
 - `PMM_Home_Dashboard_TALL.jpg` is created by [pmm-screenshots-pw](https://github.com/PaulJacobs-percona/pmm-screenshots-pw). If snapped by hand, it should be 1280x1120 pixels, to match the overlay image.
 - `PMM_Home_Dashboard_TALL_Overlay.png` is exported from `_resources/diagrams/PMM_Home_Dashboard_TALL_Overlay.drawio` using <https://app.diagrams.net/>.
 
-	1. Go to <https://app.diagrams.net/>
-	2. If it's your first time, select *Device* at the *Save diagrams to:* dialog
-	2. Click *Open existing diagram*
-	3. Navigate to `pmm-doc/_resources/diagrams` and select `PMM_Home_Dashboard_TALL_Overlay.drawio`
-	4. If the dashboard layout has changed, replace the *Guide* Layer with a new screenshot and adjust the elements on the *Overlay* layer as needed (To show layers, click View --> Layers). Untick the *Guide* Layer so it is not exported.
-	5. Click File --> Export as --> PNG
-	6. In the *Image settings* dialog, use these settings:
-		- *Zoom*: 100%, Border Width: 0
-		- *Size:* Page
-		- *Transparent Background:* ON
-		- *Shadow:* OFF
-		- *Grid*: OFF
-		- *Include a copy of my diagram:* OFF
-	7. Click *Export*
-	8. Click *Device*
-	9. Navigate to `pmm-doc/docs/_resources/diagrams` and click `PMM_Home_Dashboard_TALL_Overlay.png`
-	10. Click *Save* and overwrite the current file
+    1. Go to <https://app.diagrams.net/>
+    2. If it's your first time, select *Device* at the *Save diagrams to:* dialog
+    2. Click *Open existing diagram*
+    3. Navigate to `pmm-doc/_resources/diagrams` and select `PMM_Home_Dashboard_TALL_Overlay.drawio`
+    4. If the dashboard layout has changed, replace the *Guide* Layer with a new screenshot and adjust the elements on the *Overlay* layer as needed (To show layers, click View --> Layers). Untick the *Guide* Layer so it is not exported.
+    5. Click File --> Export as --> PNG
+    6. In the *Image settings* dialog, use these settings:
+        - *Zoom*: 100%, Border Width: 0
+        - *Size:* Page
+        - *Transparent Background:* ON
+        - *Shadow:* OFF
+        - *Grid*: OFF
+        - *Include a copy of my diagram:* OFF
+    7. Click *Export*
+    8. Click *Device*
+    9. Navigate to `pmm-doc/docs/_resources/diagrams` and click `PMM_Home_Dashboard_TALL_Overlay.png`
+    10. Click *Save* and overwrite the current file
 
 The overlay image is merged with a copy of the latest home dashboard using [`composite`](https://imagemagick.org/script/composite.php), one of the ImageMagick tools.
 
@@ -166,23 +167,23 @@ composite _resources/diagrams/PMM_Home_Dashboard_TALL_Overlay.png docs/_images/P
 
 The GitHub actions build job performs a basic spell and grammar check. You can do these yourself on the command line if you have [Node.js](https://nodejs.org/en/download/) installed.
 
-	npm i markdown-spellcheck -g
+    npm i markdown-spellcheck -g
     mdspell --report --en-us --ignore-acronyms --ignore-numbers docs/<path to file>.md
 
 To check all files:
 
-	mdspell --report --en-us --ignore-acronyms --ignore-numbers "docs/**/*.md"
+    mdspell --report --en-us --ignore-acronyms --ignore-numbers "docs/**/*.md"
 
 Add any custom dictionary words to `.spelling`. If spell checking fails, the GitHub action will fail too, but after the MkDocs build and so can be safely ignored. The `publish` branch will still have the latest build and can be used. Meanwhile, see what the spelling error is and either fix it or add the word to `.spelling`.
 
 Grammar is checked using [`write-good`](https://github.com/btford/write-good). (The results of this check are ignored and don't affect the GitHub action.)
 
-	npm i write-good -g
-	write-good docs/<path to file>.md
+    npm i write-good -g
+    write-good docs/<path to file>.md
 
 To check all files:
 
-	write-good docs/**/*.md
+    write-good docs/**/*.md
 
 ## Link checking
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Percona Monitoring and Management (PMM) Documentation
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fpercona%2Fpmm-doc.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fpercona%2Fpmm-doc?ref=badge_shield)
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/9db2c2b3-f6a8-4d56-a853-8414f8580a43/deploy-status)](https://app.netlify.com/sites/pmm-doc/deploys)
+
 [Percona Monitoring and Management (PMM)](https://www.percona.com/software/database-tools/percona-monitoring-and-management) is a database monitoring solution that is free and open-source.
 
 This repo holds the source files for the PMM technical documentation published at <https://www.percona.com/doc/percona-monitoring-and-management/>.

--- a/mkdocs-netlify.yml
+++ b/mkdocs-netlify.yml
@@ -1,3 +1,5 @@
+# MkDocs configuration for Netlify builds
+
 site_name: Percona Monitoring and Management (Preview)
 site_description: Documentation
 site_author: Percona LLC
@@ -19,8 +21,6 @@ theme:
     # Light mode
     - media: "(prefers-color-scheme: light)"
       scheme: percona-light
-#      primary: amber
-#      accent: indigo
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
@@ -28,8 +28,6 @@ theme:
     # Dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-#      primary: blue
-#      accent: blue
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode

--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -1,0 +1,214 @@
+site_name: Percona Monitoring and Management
+site_description: Documentation
+site_author: Percona LLC
+copyright: Percona LLC, &#169; 2021
+use_directory_urls: false
+
+theme:
+  name: material
+
+extra_css:
+  - https://unicons.iconscout.com/release/v3.0.3/css/line.css
+  - https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css
+#  - css/version-select.css
+#  - css/toctree.css
+#  - css/percona.css
+
+#extra_javascript:
+#  - js/version-select.js
+#  - js/toctree.js
+
+markdown_extensions:
+  - attr_list
+  - toc
+#      permalink: True
+  - admonition
+  - def_list   # https://michelf.ca/projects/php-markdown/extra/#def-list
+  - meta
+  - smarty:
+        smart_angled_quotes: true
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.tabbed
+  - pymdownx.tilde
+  - pymdownx.superfences
+  - pymdownx.highlight:
+        linenums: false
+  - plantuml_markdown
+
+plugins:
+  - search
+#  - git-revision-date
+#  - bootstrap-tables
+#  - section-index # Adds links to nodes - comment out when creating PDF
+#  - htmlproofer # Uncomment to check links - but extends build time significantly
+  - macros:
+        include_yaml:
+          - 'variables.yml' # Use in markdown as '{{ VAR }}'
+  - exclude: # Don't process these files
+        glob:
+          - setting-up/client/docker.md # Moved to setting-up/client/index.md
+  - with-pdf: # https://github.com/orzih/mkdocs-with-pdf
+        output_path: '_pdf/PerconaMonitoringAndManagement-2.16.0.pdf'
+        cover_title: 'Documentation'
+        cover_subtitle: 2.16.0 (April 15, 2021)
+        author: 'Percona Technical Documentation Team'
+        cover_logo: docs/_images/PMM_Logo.svg
+        debug_html: false
+        custom_template_path: _resources/templates
+#        enabled_if_env: ENABLE_PDF_EXPORT
+
+#extra: # Used in main.html template and can't be externalised
+#    open_issue_text: '<i class="uil uil-exclamation-triangle"></i> Report a problem
+#        with this page'
+#    open_issue_subject: 'PMM2: doc issue on page '
+#    open_issue_body: 'Please describe the issue here'
+#    open_issue_tooltip: 'Report an issue with this page on GitHub'
+#    edit_page_text: '<i class="uil uil-pen"></i> <b>Edit this page</b>'
+#    updated_text: '<i class="uil uil-refresh"></i> Page updated'
+
+
+
+
+
+nav:
+  - Welcome: index.md
+  - Setting up:
+      - setting-up/index.md
+      - Server:
+          - setting-up/server/index.md
+          - setting-up/server/docker.md
+          - setting-up/server/virtual-appliance.md
+          - setting-up/server/aws.md
+          - setting-up/server/dbaas.md
+      - Client:
+          - setting-up/client/index.md
+          - setting-up/client/mysql.md
+          - setting-up/client/mongodb.md
+          - setting-up/client/postgresql.md
+          - setting-up/client/proxysql.md
+          - setting-up/client/aws.md
+          - setting-up/client/azure.md
+          - setting-up/client/google.md
+          - setting-up/client/linux.md
+          - setting-up/client/external.md
+          - setting-up/client/haproxy.md
+  - Using:
+      - using/index.md
+      - using/interface.md
+      - using/alerting.md
+      - using/query-analytics.md
+      - Percona Platform:
+          - using/platform/index.md
+          - using/platform/security-threat-tool.md
+          - using/platform/dbaas.md
+  - How to:
+      - how-to/index.md
+      - how-to/configure.md
+      - how-to/upgrade.md
+      - how-to/secure.md
+      - how-to/optimize.md
+      - how-to/annotate.md
+      - how-to/backup.md
+      - how-to/render-dashboard-images.md
+      - how-to/troubleshoot.md
+  - Details:
+      - details/index.md
+      - details/architecture.md
+      - details/interface.md
+      - Dashboards:
+          - details/dashboards/index.md
+          - Insight:
+              - details/dashboards/dashboard-home.md
+              - details/dashboards/dashboard-advanced-data-exploration.md
+              - details/dashboards/dashboard-victoriametrics.md
+              - details/dashboards/dashboard-victoriametrics-agents-overview.md
+          - PMM:
+              - details/dashboards/dashboard-inventory.md
+          - OS Dashboards:
+              - details/dashboards/dashboard-cpu-utilization-details.md
+              - details/dashboards/dashboard-disk-details.md
+              - details/dashboards/dashboard-network-details.md
+              - details/dashboards/dashboard-memory-details.md
+              - details/dashboards/dashboard-node-temperature-details.md
+              - details/dashboards/dashboard-nodes-compare.md
+              - details/dashboards/dashboard-nodes-overview.md
+              - details/dashboards/dashboard-node-summary.md
+              - details/dashboards/dashboard-numa-details.md
+              - details/dashboards/dashboard-processes-details.md
+          - Prometheus Dashboards:
+              - details/dashboards/dashboard-prometheus-exporter-status.md
+              - details/dashboards/dashboard-prometheus-exporters-overview.md
+          - MySQL Dashboards:
+              - details/dashboards/dashboard-mysql-amazon-aurora-details.md
+              - details/dashboards/dashboard-mysql-command-handler-counters-compare.md
+              - details/dashboards/dashboard-mysql-innodb-compression-details.md
+              - details/dashboards/dashboard-mysql-innodb-details.md
+              - details/dashboards/dashboard-mysql-myisam-aria-details.md
+              - details/dashboards/dashboard-mysql-myrocks-details.md
+              - details/dashboards/dashboard-mysql-instance-summary.md
+              - details/dashboards/dashboard-mysql-instances-compare.md
+              - details/dashboards/dashboard-mysql-instances-overview.md
+              - details/dashboards/dashboard-mysql-wait-event-analyses-details.md
+              - details/dashboards/dashboard-mysql-performance-schema-details.md
+              - details/dashboards/dashboard-mysql-query-response-time-details.md
+              - details/dashboards/dashboard-mysql-replication-summary.md
+              - details/dashboards/dashboard-mysql-group-replication-summary.md
+              - details/dashboards/dashboard-mysql-table-details.md
+              - details/dashboards/dashboard-mysql-user-details.md
+              - details/dashboards/dashboard-mysql-tokudb-details.md
+          - MongoDB Dashboards:
+              - details/dashboards/dashboard-mongodb-cluster-summary.md
+              - details/dashboards/dashboard-mongodb-instance-summary.md
+              - details/dashboards/dashboard-mongodb-instances-overview.md
+              - details/dashboards/dashboard-mongodb-instances-compare.md
+              - details/dashboards/dashboard-mongodb-replset-summary.md
+              - details/dashboards/dashboard-mongodb-inmemory-details.md
+              - details/dashboards/dashboard-mongodb-mmapv1-details.md
+              - details/dashboards/dashboard-mongodb-wiredtiger-details.md
+          - PostgreSQL Dashboards:
+              - details/dashboards/dashboard-postgresql-instances-overview.md
+              - details/dashboards/dashboard-postgresql-instance-summary.md
+              - details/dashboards/dashboard-postgresql-instances-compare.md
+          - ProxySQL Dashboards:
+              - details/dashboards/dashboard-proxysql-instance-summary.md
+          - HA Dashboards:
+              - details/dashboards/dashboard-pxc-galera-node-summary.md
+              - details/dashboards/dashboard-pxc-galera-cluster-summary.md
+              - details/dashboards/dashboard-pxc-galera-nodes-compare.md
+              - details/dashboards/dashboard-haproxy-instance-summary.md
+      - Commands:
+          - details/commands/index.md
+          - details/commands/pmm-admin.md
+          - details/commands/pmm-agent.md
+      - details/api.md
+      - details/victoria-metrics.md
+      - details/glossary.md
+  - faq.md
+  - Release Notes:
+      - release-notes/index.md
+      - release-notes/2.16.0.md
+      - release-notes/2.15.1.md
+      - release-notes/2.15.0.md
+      - release-notes/2.14.0.md
+      - release-notes/2.13.0.md
+      - release-notes/2.12.0.md
+      - release-notes/2.11.1.md
+      - release-notes/2.11.0.md
+      - release-notes/2.10.1.md
+      - release-notes/2.10.0.md
+      - release-notes/2.9.1.md
+      - release-notes/2.9.0.md
+      - release-notes/2.8.0.md
+      - release-notes/2.7.0.md
+      - release-notes/2.6.1.md
+      - release-notes/2.6.0.md
+      - release-notes/2.5.0.md
+      - release-notes/2.4.0.md
+      - release-notes/2.3.0.md
+      - release-notes/2.2.2.md
+      - release-notes/2.2.1.md
+      - release-notes/2.2.0.md
+      - release-notes/2.1.0.md
+      - release-notes/2.0.1.md
+      - release-notes/2.0.0.md

--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -1,3 +1,5 @@
+# MkDocs configuration for PDF output only
+
 site_name: Percona Monitoring and Management
 site_description: Documentation
 site_author: Percona LLC
@@ -10,18 +12,10 @@ theme:
 extra_css:
   - https://unicons.iconscout.com/release/v3.0.3/css/line.css
   - https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css
-#  - css/version-select.css
-#  - css/toctree.css
-#  - css/percona.css
-
-#extra_javascript:
-#  - js/version-select.js
-#  - js/toctree.js
 
 markdown_extensions:
   - attr_list
   - toc
-#      permalink: True
   - admonition
   - def_list   # https://michelf.ca/projects/php-markdown/extra/#def-list
   - meta
@@ -38,10 +32,6 @@ markdown_extensions:
 
 plugins:
   - search
-#  - git-revision-date
-#  - bootstrap-tables
-#  - section-index # Adds links to nodes - comment out when creating PDF
-#  - htmlproofer # Uncomment to check links - but extends build time significantly
   - macros:
         include_yaml:
           - 'variables.yml' # Use in markdown as '{{ VAR }}'
@@ -56,19 +46,6 @@ plugins:
         cover_logo: docs/_images/PMM_Logo.svg
         debug_html: false
         custom_template_path: _resources/templates
-#        enabled_if_env: ENABLE_PDF_EXPORT
-
-#extra: # Used in main.html template and can't be externalised
-#    open_issue_text: '<i class="uil uil-exclamation-triangle"></i> Report a problem
-#        with this page'
-#    open_issue_subject: 'PMM2: doc issue on page '
-#    open_issue_body: 'Please describe the issue here'
-#    open_issue_tooltip: 'Report an issue with this page on GitHub'
-#    edit_page_text: '<i class="uil uil-pen"></i> <b>Edit this page</b>'
-#    updated_text: '<i class="uil uil-refresh"></i> Page updated'
-
-
-
 
 
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,6 @@
+# Default MkDocs configuration for HTML publishing to percona.com
+# There is no theme unless specified on the command line. See README.md
+
 site_name: Percona Monitoring and Management
 site_description: Documentation
 site_author: Percona LLC


### PR DESCRIPTION
Separated (again) mkdocs config for PDF generation. This makes build instructions easier as no config file editing is needed. The downside is the need to keep the `nav` element in sync. 