### PR TITLE
Update docker.md

### DIFF
--- a/docs/setting-up/server/docker.md
+++ b/docs/setting-up/server/docker.md
@@ -30,14 +30,18 @@ We maintain a [Docker image for PMM Server][DOCKERHUB]. This section shows how t
 
     ```sh
     sudo docker run --detach --restart always \
-    --publish 80:80 --publish 443:443 \
+    --publish 443:443 \
     --volumes-from pmm-data --name pmm-server \
     percona/pmm-server:2
     ```
-
+    > Optionally you can enable http (insecure) by including `--publish 80:80` in the above docker run command however note that PMM Client *requires* TLS to communication with the server so will only work on the secure port. 
+ 
     You can disable manual updates via the Home Dashboard *PMM Upgrade* panel by adding `-e DISABLE_UPDATES=true` to the `docker run` command.
+   
 
-4. In a web browser, visit *server hostname*:80 or *server hostname*:443 to see the PMM user interface.
+4. In a web browser, visit *https://server hostname*:443 (or *//server hostname*:80 if optionally enabled) to see the PMM user interface.
+
+    > PRO Tip: Eliminate browser certificate warnings by configuring a [trusted certificate](https://www.percona.com/doc/percona-monitoring-and-management/2.x/how-to/secure.html#ssl-encryption)
 
 ### Docker environment variables
 It is possible to change some server setting by using environment variables when starting the Docker container.
@@ -82,13 +86,13 @@ You can test a new release of the PMM Server Docker image by making backups of y
 1. Find out which release you have now.
 
     ```sh
-    sudo docker exec -it pmm-server curl -u admin:admin http://localhost/v1/version
+    sudo docker exec -it pmm-server curl -u admin:admin https://localhost/v1/version
     ```
 
 	> **Tip:** Use `jq` to extract the quoted string value.
 	> ```sh
 	> sudo apt install jq # Example for Debian, Ubuntu
-	> sudo docker exec -it pmm-server curl -u admin:admin http://localhost/v1/version | jq .version
+	> sudo docker exec -it pmm-server curl -u admin:admin https://localhost/v1/version | jq .version
 	> ```
 
 2. Check the container mount points are the same (`/srv`).
@@ -121,7 +125,7 @@ You can test a new release of the PMM Server Docker image by making backups of y
     sudo docker run \
     --detach \
     --restart always \
-    --publish 80:80 --publish 443:443 \
+    --publish 443:443 \
     --volumes-from pmm-data \
     --name pmm-server \
     percona/pmm-server:2
@@ -264,7 +268,7 @@ If the host where you will run PMM Server has no internet connection, you can do
     sudo docker run \
     --detach \
     --restart always \
-    --publish 80:80 --publish 443:443 \
+    --publish 443:443 \
     --volumes-from pmm-data \
     --name pmm-server \
     percona/pmm-server:{{release}}


### PR DESCRIPTION
Suggestion from Services group to remove some of the confusion around having PMM listen both on 80 and 443 1) 80 is NOT secure and should not be run in production this way and 2) pmm client will ONLY talk over port TLS (container port 443) so should steer all communication that way.  added tip to get users to custom certificate configuration more easiliy too!

related issues:

- https://jira.percona.com/browse/PMM-3305
- https://jira.percona.com/browse/PMM-4591