### PR TITLE
Update configure.md

### DIFF
--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -95,9 +95,9 @@ We do not gather anything that would make the system identifiable, but the follo
 
 The first telemetry reporting of a new PMM Server instance is delayed by 24 hours to allow sufficient time to disable the service for those that do not wish to share any information.
 
-There is a landing page for this service, available at [check.percona.com](https://check.percona.com), which clearly explains what this service is, what it’s collecting, and how you can turn it off.
+There is a landing page for this service, available at [check.percona.com](https://check.percona.com), which clearly explains what this service is.
 
-Grafana’s [anonymous usage statistics](https://grafana.com/docs/grafana/latest/installation/configuration/#reporting-enabled) is not managed by PMM. To activate it, you must change the PMM Server container configuration after each update.
+Grafana’s [anonymous usage statistics](https://grafana.com/docs/grafana/latest/administration/configuration/#reporting-enabled) is not managed by PMM. To activate it, you must change the PMM Server container configuration after each update.
 
 As well as via the *PMM Settings* page, you can also disable telemetry with the `-e DISABLE_TELEMETRY=1` option in your docker run statement for the PMM Server.
 

--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -95,7 +95,7 @@ We do not gather anything that would make the system identifiable, but the follo
 
 The first telemetry reporting of a new PMM Server instance is delayed by 24 hours to allow sufficient time to disable the service for those that do not wish to share any information.
 
-There is a landing page for this service, available at [check.percona.com](https://check.percona.com), which clearly explains what this service is.
+The landing page for this service, [check.percona.com](https://check.percona.com), explains what this service is.
 
 Grafana’s [anonymous usage statistics](https://grafana.com/docs/grafana/latest/administration/configuration/#reporting-enabled) is not managed by PMM. To activate it, you must change the PMM Server container configuration after each update.
 


### PR DESCRIPTION
Changes in this PR:
1/ the path for grafana's telemetry changes to https://grafana.com/docs/grafana/latest/administration/configuration/#reporting-enabled
2/ the check.percona.com web page neither explains what the service is collecting nor how to turn it off. Instead, it's all explained on this very page.