### PR TITLE
pmm-admin command fails with unknown flag

### DIFF
--- a/docs/pmm-admin.md
+++ b/docs/pmm-admin.md
@@ -743,13 +743,13 @@ The following options can be used with the **pmm-admin config** command:
 `--server-insecure-ssl`
 : Enable insecure SSL (self-signed certificate).
 
-`--SERVER_PASSWORD`
+`--server-password`
 : Specify the HTTP password configured on PMM Server.
 
 `--server-ssl`
 : Enable SSL encryption for connection to PMM Server.
 
-`--SERVER_USER`
+`--server-user`
 : Specify the HTTP user configured on PMM Server (default is `pmm`).
 
 You can also use global options that apply to any other command.


### PR DESCRIPTION
The flags --SERVER_USER and --SERVER_PASSWORD (in uppercase letters) aren't accepted by the pmm-admin command in the last version of pmm-client v1. Although PMMv1 is not actively developed anymore in favor of PMMv2 at least make the documentation match with the CLI command.