### PR TITLE
Updating instructions for 2.20.0 RN

### DIFF
--- a/docs/release-notes/2.20.0.md
+++ b/docs/release-notes/2.20.0.md
@@ -28,14 +28,15 @@ Percona Monitoring and Management (PMM) is a free and open-source platform for m
 - For users who deploy PMM Server through the AWS Marketplace, AWS RDS service discovery will be executed without AWS credentials and tuning [IAM roles].
 - For Backup Management (Technical Preview), we added the ability to schedule backups so you can schedule and see already scheduled [backups] in the UI.
 
-## Important note for users of PMM via Docker who started with version 2.16.0
+## Important note for users of PMM who started out using the Docker image of 2.16.0
 
-If you started using PMM from [version 2.16] and have already upgraded to 2.17, 2.18, or 2.19, you might have some problems with PMM Server monitoring, Remove Monitoring, or RDS/Azure monitoring. If you experience a problem, we recommend you upgrade and replace the Docker container by following the official instructions for an upgrade here: <https://www.percona.com/doc/percona-monitoring-and-management/2.x/setting-up/server/docker.html#upgrade>.
-
-If you can't do this, then you need to perform additional steps after upgrading to 2.20.
+If you installed PMM [version 2.16] as a new docker image and have since used the home dashboard upgrade widget to upgrade to any of 2.17, 2.18, or 2.19, you might experience problems with monitoring the PMM server itself, Remote Monitoring, or RDS/Azure monitoring. If you experience any of these problems, you can simply run the following commands to get your instance working and it will be automatically resolved in the next release: 
 
 1. Enter the container: `docker exec -it pmm-server bash`
 2. Roll back `pmm2-client` package to stable version: `yum downgrade -y pmm2-client`
+
+Alternatively you can replace the existing Docker container with a fresh install of the latest release by following the official instructions for an upgrade here (which will guide you through taking a backup of your PMM Server and restoring it after installing a fresh docker image of PMM Server): <https://www.percona.com/doc/percona-monitoring-and-management/2.x/setting-up/server/docker.html#upgrade>.
+
 
 [Easy-install script]: https://www.percona.com/doc/percona-monitoring-and-management/2.x/setting-up/server/easy-install.html
 [Grafana 7.5]: https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v7-5


### PR DESCRIPTION
Found the blurb about the issue starting in 2.16.0 to be confusing so tried to clarify it a bit more.  Since the two commands get the user back up and running I moved that up over a backup and restore since we gloss over that users may have installed their original image with a complex docker run command.