### PR TITLE
Common Linux/macOS command for shasum

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           mike retitle 2.x "PMM2 (LATEST)" -b netlify  -p
 
       - name: Install Node.js 14.x
-        uses: percona-platform/setup-node@v2.1.2
+        uses: percona-platform/setup-node@v2
         with:
           node-version: "14"
 

--- a/docs/setting-up/server/easy-install.md
+++ b/docs/setting-up/server/easy-install.md
@@ -3,22 +3,12 @@
 !!! caution alert alert-warning "Caution"
     Download and check `get-pmm.sh` before running it to make sure you know what it does.
 
-## Linux
+## Linux or macOS
 
 ```sh
 curl -fsSL -O https://raw.githubusercontent.com/percona/pmm/PMM-2.0/get-pmm.sh \
 -O https://raw.githubusercontent.com/percona/pmm/PMM-2.0/.sha256-oneline && \
-sha256sum .sha256-oneline -c && \
-chmod +x ./get-pmm.sh && \
-./get-pmm.sh
-```
-
-## macOS
-
-```sh
-curl -fsSL -O https://raw.githubusercontent.com/percona/pmm/PMM-2.0/get-pmm.sh \
--O https://raw.githubusercontent.com/percona/pmm/PMM-2.0/.sha256-oneline && \
-shasum .sha256-oneline -c && \
+shasum -a 256 .sha256-oneline -c && \
 chmod +x ./get-pmm.sh && \
 ./get-pmm.sh
 ```


### PR DESCRIPTION
macOS 11.5 and Debian 11 both allow `shasum -a` option. Command change to use this approach to make a common code block.
https://deploy-preview-585--pmm-doc.netlify.app
