### PR TITLE
Remove SUPER from grants

### DIFF
--- a/docs/setting-up/client/mysql.md
+++ b/docs/setting-up/client/mysql.md
@@ -31,7 +31,7 @@ It is good practice to use a non-superuser account to connect PMM Client to the 
 
 ```sql
 CREATE USER 'pmm'@'localhost' IDENTIFIED BY 'pass' WITH MAX_USER_CONNECTIONS 10;
-GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO 'pmm'@'localhost';
+GRANT SELECT, PROCESS, REPLICATION CLIENT, RELOAD ON *.* TO 'pmm'@'localhost';
 ```
 
 ## Choose and configure a source


### PR DESCRIPTION
As for discussion the use of super seems to be redundant also in the code we see:
```
if !strings.Contains(grants, "RELOAD") && !strings.Contains(grants, "ALL PRIVILEGES") {
		s.l.Error("RELOAD grant not enabled, cannot rotate slowlog")
		return
	}
```
in https://github.com/percona/pmm-agent/blob/d31783a23cfd8cbe098d7e4839ca11c5cb4d16b9/agents/mysql/slowlog/slowlog.go
So we should be good to remove it and count on `RELOAD` instead