### PR TITLE
Remove --slow-log-rotation option reference

### DIFF
--- a/docs/setting-up/client/mysql.md
+++ b/docs/setting-up/client/mysql.md
@@ -168,7 +168,7 @@ When the limit is reached, PMM Client will:
 
 Only one `.old` file is kept. Older ones are deleted.
 
-You can manage log rotation yourself, for example, with [`logrotate`][LOGROTATE]. If you do, you can disable PMM Client's log rotation with the `--slow-log-rotation=false` option when adding a service with `pmm-admin add`.
+You can manage log rotation yourself, for example, with [`logrotate`][LOGROTATE]. If you do, you can disable PMM Client's log rotation by providing a negative value to `--size-slow-logs` option when adding a service with `pmm-admin add`.
 
 ### Performance Schema
 
@@ -369,13 +369,13 @@ pmm-admin add mysql --username=pmm --password=pass
 Slow query log source and log size limit (1 gigabyte), service name (`MYSQL_NODE`) and service address/port (`191.168.1.123:3306`).
 
 ```sh
-pmm-admin add mysql --query-source=slowlog --size-slow-logs=1GB --username=pmm --password=pass MYSQL_NODE 192.168.1.123:3306
+pmm-admin add mysql --query-source=slowlog --size-slow-logs=1GiB --username=pmm --password=pass MYSQL_NODE 192.168.1.123:3306
 ```
 
 Slow query log source, disabled log management (use [`logrotate`][LOGROTATE] or some other log management tool), service name (`MYSQL_NODE`) and service address/port (`191.168.1.123:3306`).
 
 ```sh
-pmm-admin add mysql --query-source=slowlog --size-slow-logs=false --username=pmm --password=pass MYSQL_NODE 192.168.1.123:3306
+pmm-admin add mysql --query-source=slowlog --size-slow-logs=-1GiB --username=pmm --password=pass MYSQL_NODE 192.168.1.123:3306
 ```
 
 Default query source (`slowlog`), service name (`{node}-mysql`), connect via socket.


### PR DESCRIPTION
The option '--slow-log-rotation' is not supported by pmm-admin 2.x. 
Instead, the negative value of '--size-slow-logs' is used to disable slow log rotation.
This is a fix for the https://jira.percona.com/browse/PMM-8890