### PR TITLE
stop hinting at port 80 use!

### DIFF
--- a/docs/release-notes/2.25.0.md
+++ b/docs/release-notes/2.25.0.md
@@ -27,7 +27,7 @@ Percona Monitoring and Management (PMM) is a free and open-source platform for m
 
 
 - **Enhanced PostgreSQL monitoring**
-    - You can now [specify custom database names] (https://deploy-preview-643--pmm-doc.netlify.app/details/commands/pmm-admin.html#postgresql) when adding PostgreSQL Servers for monitoring. Previous PMM versions always used the default `postgres` name instead. 
+    - You can now [specify custom database names](https://www.percona.com/doc/percona-monitoring-and-management/2.x/details/commands/pmm-admin.html#postgresql) when adding PostgreSQL Servers for monitoring. Previous PMM versions always used the default `postgres` name instead. 
 
 
     -  Added support for the new version of `pg_stat_monitor` extension. [Release Candidate v1.0.0-rc.1](https://github.com/percona/pg_stat_monitor/releases/tag/1.0.0-rc.1) brings many new PostgreSQL metrics, Dashboards and Query Analytics! To find out about all the features available in the new `pg_stat_monitor` version, see the [pg_stat_monitor User guide](https://github.com/percona/pg_stat_monitor/blob/1.0.0-rc.1/docs/USER_GUIDE.md) 

--- a/docs/setting-up/server/docker.md
+++ b/docs/setting-up/server/docker.md
@@ -57,7 +57,7 @@ How to run PMM Server with Docker based on our [Docker image].
     percona/pmm-server:2
     ```
 
-4. In a web browser, visit `https://localhost:443` to see the PMM user interface. (If you are accessing the docker host remotely, replace `localhost` with the IP or server name of the host.)
+4. Visit `https://localhost:443` to see the PMM user interface in a web browser. (If you are accessing the docker host remotely, replace `localhost` with the IP or server name of the host.)
 
 ## Backup
 

--- a/docs/setting-up/server/docker.md
+++ b/docs/setting-up/server/docker.md
@@ -57,7 +57,7 @@ How to run PMM Server with Docker based on our [Docker image].
     percona/pmm-server:2
     ```
 
-4. In a web browser, visit `https://localhost:443` (or `http://localhost:80` if enabled) to see the PMM user interface. (If you are accessing the docker host remotely, replace `localhost` with the IP or server name of the host.)
+4. In a web browser, visit `https://localhost:443` to see the PMM user interface. (If you are accessing the docker host remotely, replace `localhost` with the IP or server name of the host.)
 
 ## Backup
 


### PR DESCRIPTION
Removed reference to HTTP use as the way that was worded originally made it sound like if port 80 was enabled you should use that instead...