### PR TITLE
Suggest using a monitoring account

### DIFF
--- a/docs/setting-up/client/proxysql.md
+++ b/docs/setting-up/client/proxysql.md
@@ -5,17 +5,18 @@ Use the `proxysql` alias to enable ProxySQL performance metrics monitoring.
 ## USAGE
 
 ```sh
-pmm-admin add proxysql --username=admin --password=admin
+pmm-admin add proxysql --username=pmm --password=pmm
 ```
 
-where `username` and `password` are credentials for the administration interface of the monitored ProxySQL instance.
+where `username` and `password` are credentials for the administration interface of the monitored ProxySQL instance. 
+You should configure a read-only account for monitoring using the [`admin-stats_credentials`](https://proxysql.com/documentation/global-variables/admin-variables/#admin-stats_credentials) variable in ProxySQL
 
 Additionally, two positional arguments can be appended to the command line flags: a service name to be used by PMM, and a service address. If not specified, they are substituted automatically as `<node>-proxysql` and `127.0.0.1:6032`.
 
 The output of this command may look as follows:
 
 ```sh
-pmm-admin add proxysql --username=admin --password=admin
+pmm-admin add proxysql --username=pmm --password=pmm
 ```
 
 ```text


### PR DESCRIPTION
* Updated username and password using `admin` to `pmm`, consistent with later examples
* Added note about using `admin-stats_credentials` to allow read-only access for the monitoring account

N.B. this is based upon the presumption that PMM does not need to be able to make changes to ProxySQL.