### PR TITLE
docker-way upgrade without external access was broken for versions <= 2.23.0 (#684)

### DIFF
--- a/docs/release-notes/2.25.0.md
+++ b/docs/release-notes/2.25.0.md
@@ -20,7 +20,7 @@
 
 Percona Monitoring and Management (PMM) is a free and open-source platform for managing and monitoring MySQL, MongoDB, and PostgreSQL performance.
 
-!!! caution alert alert-warning "Important note for users considering docker way update to PMM 2.25.0"
+!!! caution alert alert-warning "Important note for users considering docker way upgrade to PMM 2.25.0"
     If you upgrade from a PMM version less than or equal to 2.23.0 using docker, it will fail if your PMM does not have external access (access to 'repo. percona.com'). Thus, it is recommended to upgrade to PMM 2.26.0 instead.
 See [PMM-9416](https://jira.percona.com/browse/PMM-9416) for more details. 
 

--- a/docs/release-notes/2.25.0.md
+++ b/docs/release-notes/2.25.0.md
@@ -20,6 +20,9 @@
 
 Percona Monitoring and Management (PMM) is a free and open-source platform for managing and monitoring MySQL, MongoDB, and PostgreSQL performance.
 
+!!! caution alert alert-warning "Important note for users considering docker way update to PMM 2.25.0"
+    Docker way update (replacing the image) when updating from versions <= 2.23.0 would fail if your PMM doesn't have external access (access to `repo.percona.com`). See [PMM-9416](https://jira.percona.com/browse/PMM-9416) for more details. Please update to 2.26.0 instead.
+
 ## Release Highlights 
 - **Percona Platform (Technology Preview):** 
     - Connect Percona Monitoring and Management (PMM) to [Percona Platform](https://www.percona.com/software/percona-platform) to boost the monitoring capabilities of your PMM installations and access all your Percona accounts and services from one single, centralized location. For more information, see the [Percona Platform Portal documentation](https://docs.percona.com/percona-platform/connect-pmm.html)

--- a/docs/release-notes/2.25.0.md
+++ b/docs/release-notes/2.25.0.md
@@ -21,7 +21,9 @@
 Percona Monitoring and Management (PMM) is a free and open-source platform for managing and monitoring MySQL, MongoDB, and PostgreSQL performance.
 
 !!! caution alert alert-warning "Important note for users considering docker way update to PMM 2.25.0"
-    Docker way update (replacing the image) when updating from versions <= 2.23.0 would fail if your PMM doesn't have external access (access to `repo.percona.com`). See [PMM-9416](https://jira.percona.com/browse/PMM-9416) for more details. Please update to 2.26.0 instead.
+    If you upgrade from a PMM version less than or equal to 2.23.0 using docker, it will fail if your PMM does not have external access (access to 'repo. percona.com'). Thus, it is recommended to upgrade to PMM 2.26.0 instead.
+See [PMM-9416](https://jira.percona.com/browse/PMM-9416) for more details. 
+
 
 ## Release Highlights 
 - **Percona Platform (Technology Preview):** 

--- a/docs/release-notes/2.26.0.md
+++ b/docs/release-notes/2.26.0.md
@@ -80,7 +80,7 @@ This release introduces major changes to the core structure of rule templates. A
 * [PMM-9416](https://jira.percona.com/browse/PMM-9416): Docker way update (replacing the image) fails when updating from versions <= 2.23.0
 
     !!! caution alert alert-warning
-        Please update directly to 2.26.0 instead of 2.25.0 when updating from versions <= 2.23.0 if your PMM doesn't have external access (access to `repo.percona.com`).
+        It is recommended to upgrade directly to PMM 2.26.0 instead of 2.25.0 when updating from versions less than or equal to PMM 2.23.0 if your PMM doesn't have external access (access to `repo.percona.com`).
 
 * [PMM-8867](https://jira.percona.com/browse/PMM-8867): Fixed an issue for PMM Client installation using the tarball script (without using RPMs) where the configuration was getting lost due to the configuration file pmm-agent.yml being recreated.
 * [PMM-8094](https://jira.percona.com/browse/PMM-8094): DBaaS - Fixed an issue for paused clusters that froze with PSMDB v1.8 operators when all the pods were terminated, providing no cluster resumption option.

--- a/docs/release-notes/2.26.0.md
+++ b/docs/release-notes/2.26.0.md
@@ -77,7 +77,7 @@ This release introduces major changes to the core structure of rule templates. A
 
 ## Bugs Fixed
 
-* [PMM-9416](https://jira.percona.com/browse/PMM-9416): Docker way update (replacing the image) fails when updating from versions <= 2.23.0
+* * [PMM-9416](https://jira.percona.com/browse/PMM-9416): Upgrading to PMM 2.25.0 using docker (replacing the image) fails when upgrading from versions less than or equal to 2.23.0.
 
     !!! caution alert alert-warning
         It is recommended to upgrade directly to PMM 2.26.0 instead of 2.25.0 when updating from versions less than or equal to PMM 2.23.0 if your PMM doesn't have external access (access to `repo.percona.com`).

--- a/docs/release-notes/2.26.0.md
+++ b/docs/release-notes/2.26.0.md
@@ -77,6 +77,11 @@ This release introduces major changes to the core structure of rule templates. A
 
 ## Bugs Fixed
 
+* [PMM-9416](https://jira.percona.com/browse/PMM-9416): Docker way update (replacing the image) fails when updating from versions <= 2.23.0
+
+    !!! caution alert alert-warning
+        Please update directly to 2.26.0 instead of 2.25.0 when updating from versions <= 2.23.0 if your PMM doesn't have external access (access to `repo.percona.com`).
+
 * [PMM-8867](https://jira.percona.com/browse/PMM-8867): Fixed an issue for PMM Client installation using the tarball script (without using RPMs) where the configuration was getting lost due to the configuration file pmm-agent.yml being recreated.
 * [PMM-8094](https://jira.percona.com/browse/PMM-8094): DBaaS - Fixed an issue for paused clusters that froze with PSMDB v1.8 operators when all the pods were terminated, providing no cluster resumption option.
 * [PMM-8535](https://jira.percona.com/browse/PMM-8535): DBaaS - Repeating error after force unregister 


### PR DESCRIPTION
adding alert for docker way update to 2.25.0