### PR TITLE
PMM-9713 change victoriametrics parameters

### DIFF
--- a/docs/details/victoria-metrics.md
+++ b/docs/details/victoria-metrics.md
@@ -38,10 +38,9 @@ As a result of the move to VictoriaMetrics some direct Prometheus paths are no l
 ## Environment variables
 
 
-PMM sets the following flags that allow users to set all other [VictoriaMetrics parameters](https://docs.victoriametrics.com/#list-of-command-line-flags) as environment variables:
-
-- `-envflag.enable`  
-- `-envflag.prefix=VM_` - The environment variable must be prepended with `VM_`.
+PMM predefines certain flags that allow users to set all other [VictoriaMetrics parameters](https://docs.victoriametrics.com/#list-of-command-line-flags) as environment variables:
+ 
+The environment variable must be prepended with `VM_`.
 
 **Example**
 

--- a/docs/details/victoria-metrics.md
+++ b/docs/details/victoria-metrics.md
@@ -48,7 +48,7 @@ PMM sets the following flags that allow users to set all other [VictoriaMetrics 
 To set downsampling, use the `downsampling.period` parameter as follows:
 
 ```
--e VM_downsampling.period=20d:10m,120d:2h
+-e VM_downsampling_period=20d:10m,120d:2h
 ```
 
 This instructs VictoriaMetrics to [deduplicate](https://docs.victoriametrics.com/#deduplication) samples older than 20 days with 10 mins intervals and samples older than 120 days with two-hour intervals.

--- a/docs/details/victoria-metrics.md
+++ b/docs/details/victoria-metrics.md
@@ -33,6 +33,28 @@ As a result of the move to VictoriaMetrics some direct Prometheus paths are no l
 | `/prometheus/status`            | Some information at `/prometheus/metrics`. High cardinality metrics information at `/prometheus/api/v1/status/tsdb`.
 | `/prometheus/targets`           | `/victoriametrics/targets`
 
+
+
+## Environment variables
+
+
+PMM sets the following flags that allow users to set all other [VictoriaMetrics parameters](https://docs.victoriametrics.com/#list-of-command-line-flags) as environment variables:
+
+- `-envflag.enable`  
+- `-envflag.prefix=VM_` - The environment variable must be prepended with `VM_`.
+
+**Example**
+
+To set downsampling, use the `downsampling.period` parameter as follows:
+
+```
+-e VM_downsampling.period=20d:10m,120d:2h
+```
+
+This instructs VictoriaMetrics to [deduplicate](https://docs.victoriametrics.com/#deduplication) samples older than 20 days with 10 mins intervals and to deduplicate samples older than 120 days with two-hour intervals.
+
+
+
 ## Troubleshooting
 
 To troubleshoot issues, see the VictoriaMetrics [troubleshooting documentation](https://victoriametrics.github.io/#troubleshooting).

--- a/docs/details/victoria-metrics.md
+++ b/docs/details/victoria-metrics.md
@@ -51,7 +51,7 @@ To set downsampling, use the `downsampling.period` parameter as follows:
 -e VM_downsampling.period=20d:10m,120d:2h
 ```
 
-This instructs VictoriaMetrics to [deduplicate](https://docs.victoriametrics.com/#deduplication) samples older than 20 days with 10 mins intervals and to deduplicate samples older than 120 days with two-hour intervals.
+This instructs VictoriaMetrics to [deduplicate](https://docs.victoriametrics.com/#deduplication) samples older than 20 days with 10 mins intervals and samples older than 120 days with two-hour intervals.
 
 
 


### PR DESCRIPTION
PMM can set the following flags that allow users to set all other VictoriaMetrics parameters as environment variables:

-envflag.enable 
-envflag.prefix=VM_. The environment variable must be prepended with VM_