### PR TITLE
Update check development pages to note that custom check development …

### DIFF
--- a/docs/details/develop-checks/checks-v1.md
+++ b/docs/details/develop-checks/checks-v1.md
@@ -210,6 +210,9 @@ Expand the table below for the list of checks types that you can use to define y
     | MONGODB_BUILDINFO    | Executes db.adminCommand( { buildInfo:  1 } ) against MongoDB's "admin" database.  For more information, see [buildInfo](https://docs.mongodb.com/manual/reference/command/buildInfo/) | No|
 
 ## Develop version 1 checks
+!!! note alert alert-primary "Development / Debugging Only"
+    Note that V1 check development in PMM 2.26/2.27 is currently for **debugging only** and **NOT for production use!**  Future releases plan to include the option to run custom local checks in addition to hosted Percona Platform checks.   
+
 To develop custom checks for PMM 2.26 and 2.27: 
 
 1. Install the latest PMM Server and PMM Client builds following the [installation instructions](https://www.percona.com/software/pmm/quickstart#). 

--- a/docs/details/develop-checks/checks-v2.md
+++ b/docs/details/develop-checks/checks-v2.md
@@ -179,6 +179,9 @@ Expand the table below for the list of checks types that you can use to define y
 
 
 ## Develop version 2 checks
+!!! note alert alert-primary "Development / Debugging Only"
+    Note that V2 check development in PMM 2.28+ is currently for **debugging only** and **NOT for production use!**  Future releases plan to include the option to run custom local checks in addition to hosted Percona Platform checks.   
+
 To develop custom checks for PMM 2.28 and later: 
 
 1. Install the latest PMM Server and PMM Client builds following the [installation instructions](https://www.percona.com/software/pmm/quickstart#). 


### PR DESCRIPTION
…is currently debugging/testing only.

Documentation should note that local checks are for testing/debugging only and aren't intended for production use.  In future versions, when local checks are fully supported, the documentation should be updated to remove this limitation. 