### PR TITLE
Add note about production safety to check development

### DIFF
--- a/docs/details/develop-checks/checks-v1.md
+++ b/docs/details/develop-checks/checks-v1.md
@@ -210,6 +210,10 @@ Expand the table below for the list of checks types that you can use to define y
     | MONGODB_BUILDINFO    | Executes db.adminCommand( { buildInfo:  1 } ) against MongoDB's "admin" database.  For more information, see [buildInfo](https://docs.mongodb.com/manual/reference/command/buildInfo/) | No|
 
 ## Develop version 1 checks
+
+!!! note alert alert-primary "Development / Debugging Only"
+    Note that V1 check development in PMM 2.26/2.27 is currently for **debugging only** and **NOT for production use!**  Future releases plan to include the option to run custom local checks in addition to hosted Percona Platform checks. 
+    
 To develop custom checks for PMM 2.26 and 2.27: 
 
 1. Install the latest PMM Server and PMM Client builds following the [installation instructions](https://www.percona.com/software/pmm/quickstart#). 

--- a/docs/details/develop-checks/checks-v2.md
+++ b/docs/details/develop-checks/checks-v2.md
@@ -179,6 +179,10 @@ Expand the table below for the list of checks types that you can use to define y
 
 
 ## Develop version 2 checks
+
+!!! note alert alert-primary "Development / Debugging Only"
+    Note that V2 check development in PMM 2.28+ is currently for **debugging only** and **NOT for production use!**  Future releases plan to include the option to run custom local checks in addition to hosted Percona Platform checks. 
+    
 To develop custom checks for PMM 2.28 and later: 
 
 1. Install the latest PMM Server and PMM Client builds following the [installation instructions](https://www.percona.com/software/pmm/quickstart#). 


### PR DESCRIPTION
As advisor check development isn't production ready, ensure there is a warning that the process should not be used in a production server and is for debugging/testing only.