### PR TITLE
PMM-10546 PMM-admin inventory add agent

### DIFF
--- a/docs/details/commands/pmm-admin.md
+++ b/docs/details/commands/pmm-admin.md
@@ -14,6 +14,8 @@
 
 DATABASE:= [[MongoDB](#mongodb) | [MySQL](#mysql) | [PostgreSQL](#postgresql) | [ProxySQL](#proxysql)]
 
+`pmm-admin inventory add agent [FLAGS] [NAME] [ADDRESS]` (This command is available starting with PMM 2.30.0.)
+
 `pmm-admin add --pmm-agent-listen-port=LISTEN_PORT DATABASE [FLAGS] [NAME] [ADDRESS]`
 
 `pmm-admin add external [FLAGS] [NAME] [ADDRESS]` (CAUTION: Technical preview feature)


### PR DESCRIPTION
Explicitly set a more detailed level of logging if this is needed so that by default people will have fewer logs, and this will simplify troubleshooting for them and let them store more meaningful logs