### PR TITLE
Correct name of the operator for pxc

### DIFF
--- a/docs/release-notes/2.30.0.md
+++ b/docs/release-notes/2.30.0.md
@@ -48,7 +48,7 @@ Enhanced the user experience by simplifying the configuration and deployment of 
 
 ### Operators support
 
-PMM now supports Percona Operators MySQL (1.11) and MongoDB (1.11).
+PMM now supports Percona Operator for MySQL based on Percona XtraDB Cluster (1.11) and MongoDB (1.11).
 
 PMM now supports Percona XtraDB Cluster (PXC) 1.11.0.
 

--- a/docs/release-notes/2.30.0.md
+++ b/docs/release-notes/2.30.0.md
@@ -48,10 +48,7 @@ Enhanced the user experience by simplifying the configuration and deployment of 
 
 ### Operators support
 
-PMM now supports Percona Operator for MySQL based on Percona XtraDB Cluster (1.11) and MongoDB (1.11).
-
-PMM now supports Percona XtraDB Cluster (PXC) 1.11.0.
-
+PMM now supports Percona Operator for MySQL based on Percona XtraDB Cluster (1.11).
 
 
 


### PR DESCRIPTION
Correcting the names and versions

- PMM doesn't support MySQL Operator, only  PXC  based 
- mongoDB operator 1.11 was added in https://jira.percona.com/browse/PMM-9178  (pmm 2.27) 