### PR TITLE
Added ref to enabling pgsm_enable_query_plan.

### DIFF
--- a/docs/setting-up/client/postgresql.md
+++ b/docs/setting-up/client/postgresql.md
@@ -190,15 +190,23 @@ You can now [add the service](#add-service).
 
     You can get a list of other available settings with `SELECT * FROM pg_stat_monitor_settings;`.
 
-    Another important parameter is:
+    One important parameter is:
     ```ini
     pg_stat_monitor.pgsm_normalized_query
     ```
 
     If the value is set to 1, the actual query values are replaced by placeholders. If the value is 0, the examples are given in QAN. Examples can be found in QAN details tab example.
+    
+    Another important parameter is:
+    
+    ```ini
+    pg_stat_monitor.pgsm_enable_query_plan
+    ```
+    
+    If the value is set to 1, the explain plan for each query is saved. The plan is available in the QAN dashboard after selecting the query, in the `Plan` tab.
 
     !!! note alert alert-primary ""
-        See [`pg_stat_monitor` GitHub repository](https://github.com/percona/pg_stat_monitor/blob/master/docs/USER_GUIDE.md#configuration) for details about available parameters.
+        See [`pg_stat_monitor` Configuration Parameters documentation page](https://docs.percona.com/pg-stat-monitor/configuration.html) for details about available parameters.
 
 3. Start or restart your PostgreSQL instance. The extension starts capturing statistics from every database.
 


### PR DESCRIPTION
With pg_stat_monitor.pgsm_enable_query_plan we can enable a very important feature of pg_stat_monitor, that is saving explain plans for queries. They can be viewed in the QAN dashboard, in the "Plan" tab (which is something we don't have with pg_stat_statements).

Additionally, fixed broken link to github page referring to available parameters to tune, which now points to our online docs.