### PR TITLE
Fix supported MySQL backup setups

### DIFF
--- a/docs/using/backup.md
+++ b/docs/using/backup.md
@@ -2,11 +2,6 @@
 
 ## Supported setups 
 
-**- MySQL database server with support for:**
-    
-  - Creating and restoring physical backups
-  - Storing backups to Amazon S3-compatible object storage 
-
 **- MongoDB replica set setups (GA) with support for:**
 
   -  Storing backups on Amazon S3-compatible object storageand on mounted filesystem
@@ -19,7 +14,7 @@
 **- MySQL database server (Technical Preview) with support for:**
     
   - Creating and restoring physical backups
-  - Storing backups to Amazon S3 
+  - Storing backups to Amazon S3-compatible object storage  
 
 
 ## Prerequisites


### PR DESCRIPTION
Follow-up of PR #917 & PR #916.

The net effect of these two PRs about MySQL supported setups was that we have two sections for MySQL.

This PR fixes the situation by:

- removing one duplicate section
- making sure S3-compatible is still mentioned

Thanks