### PR TITLE
MongoDB Backup limitations - remove confusing line

### DIFF
--- a/docs/using/mongodb_limitations.md
+++ b/docs/using/mongodb_limitations.md
@@ -39,8 +39,6 @@ Creating and restoring MongoDB backups in PMM currently has the following limita
   }
 </style>
 
-| Physical         | No   | Local    | No            | Partial                                
-=======
 | Operation (Backup or Restore) | Backup type (Logical or Physical) | Full or PITR | Storage type (S3 or Local) | DB running in container (Containerized) | Support level|                                                                    
 | -------------- | ---------------- | ---- | -------- | ------------- | --------------------------------------- |
 | Backup         | Logical          | PITR  | S3       | Yes           | <b style="color:#5794f2;"><b style="color:#5794f2;">Full</b></b>                                  |                                                                               |


### PR DESCRIPTION
Remove a confusing line.
I wasn't able to understand what was that for. Perhaps something old?

I am sharing a screenshot below (see the highlighted text) from [link](https://docs.percona.com/percona-monitoring-and-management/using/mongodb_limitations.html). 
If this is not the correct fix, or if you have any context on the removed line, please let me know. Happy to change this PR.

Thanks

---

![issue](https://user-images.githubusercontent.com/31849787/203290948-d7d198c0-ebfc-4a1d-85c0-2d509e930c0c.png)
