### PR TITLE
Backup - fix wrongly formatted list

### DIFF
--- a/docs/using/backup.md
+++ b/docs/using/backup.md
@@ -215,6 +215,7 @@ During restoring, PMM disables all the scheduled backup tasks for the current se
 
 ### Post-restore requirements for MongoDB
 Restoring from a physical backup will cause all **mongo** and **pbm-agent** instances to shut down. To bring them back up:
+
 1. Restart all **mongod** (and **mongos** if present) nodes.
 2. Restart all **pbm-agents**.
 


### PR DESCRIPTION
As it was, from [link](https://pmm-doc-2-32-pr-923.onrender.com/using/backup.html#post-restore-requirements-for-mongodb):

![wrongly-formatted-list](https://user-images.githubusercontent.com/31849787/203293967-ed2a0bec-83aa-44d2-aa6f-6e6b468d8265.png)

After the fix:

![after-the-fix](https://user-images.githubusercontent.com/31849787/203295543-8919b41f-1c12-4081-add4-aecf1ad6eb27.png)

