### PR TITLE
Add docker rename step

### DIFF
--- a/docs/setting-up/server/docker.md
+++ b/docs/setting-up/server/docker.md
@@ -229,7 +229,14 @@ docker cp <containerId>:/srv /target/host/directory
     docker pull percona/pmm-server:2
     ```
 
-4. Run it.
+4. Rename the original container
+
+    ```sh
+    docker rename pmm-server pmm-server-old
+    ```
+
+
+5. Run it.
 
     ```sh
     docker run \


### PR DESCRIPTION
as is, the existing documentation won't work until you rename the old container.  This is the error you would get

```docker: Error response from daemon: Conflict. The container name "/pmm-server" is already in use by container "0270fbfd68911886f1121168e84fff95d067257761395b3e478b7409c3124a3e". You have to remove (or rename) that container to be able to reuse that name.```