### PR TITLE
PMM-11445: Re-enable Edit/View Source icons

### DIFF
--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -15,6 +15,9 @@ theme:
   custom_dir: overrides
   logo: _images/percona-logo.svg
   favicon: _images/percona-favicon.ico
+  features:
+    - content.action.edit
+    - content.action.view
   palette:
     # Light mode
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
Material Theme for MkDocs version 9.x changed the default behavior of the "Edit this page" functionality. Now both editing and viewing the source code must be explicitly enabled:

https://squidfunk.github.io/mkdocs-material/upgrade/#upgrading-from-8x-to-9x

Change `mkdocs-base.yml` to enable both editing and viewing of source code again.

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>