### PR TITLE
Fix alerting link in release notes

### DIFF
--- a/docs/release-notes/2.31.0.md
+++ b/docs/release-notes/2.31.0.md
@@ -52,7 +52,7 @@ The **Alert Rules** tab has also evolved into a more efficient interface with an
 
 As an important and generally useful feature, this new Alerting feature is now enabled by default and ready to use in production! 
 
-For more information about Percona Alerting, check out [Percona Alerting](..\using\alerting.html).
+For more information about Percona Alerting, check out [Percona Alerting](../get-started/alerting.md).
 
 ### Deprecated Integrated Alerting
 


### PR DESCRIPTION
Issue introduced by PR #929 (where the file was moved to "get-started" folder).