### PR TITLE
Fix broken link to public address

### DIFF
--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -19,7 +19,7 @@ On the left are the selector tabs:
     - [DBaaS](#dbaas)
     - [Alerting](#alerting)
     - [Microsoft Azure Monitoring](#microsoft-azure-monitoring)
-    - [Public Address {: #public-address-1 }](#public-address--public-address-1-)
+    - [Public Address](#public-address)
   - [SSH Key](#ssh-key)
   - [Alertmanager integration](#alertmanager-integration)
   - [Percona Platform](#percona-platform)


### PR DESCRIPTION
The link to public address section was broken

<img width="507" alt="Screenshot 2023-03-11 at 14 51 12" src="https://user-images.githubusercontent.com/81549/224482994-52041bde-fd68-4f2d-a67b-507650e7e834.png">
