### PR TITLE
modify the sentence "Silences specify periods of time to suppress & notifications. " [add alerts]

### DIFF
--- a/docs/get-started/alerting.md
+++ b/docs/get-started/alerting.md
@@ -38,7 +38,7 @@ You can check the  alert templates available for your account under **Alerting >
 3. Custom template files available in your  ``yaml srv/alerting/templates`` directory. PMM loads them during startup.
 
 ### Silences
-Silences specify periods of time to suppress notifications. During a silence, PMM continues to track metrics and trigger alerts but does not send notifications to the specified contact points. Once the specified silence expires, notifications are resumed.
+Silences specify periods of time to suppress alerts and their associated notifications. During a silence, PMM continues to track metrics and trigger alerts but does not send notifications to the specified contact points. Once the silence expires alerts and notifications will resume.
 
 For example, you can create a silence to suppress trivial notifications during weekends.
 


### PR DESCRIPTION


original: ### Silences
Silences specify periods of time to suppress notifications.... During a silence, PMM continues to track metrics and trigger alerts but does not send notifications to the specified contact points. Once the specified silence expires, notifications are resumed.

Changed to: Silences specify periods of time to suppress ****alerts and their associated**** notifications...Once the silence expires **alerts and notifications** will resume. It is not very precise to say they only silence notifications (by omitting the ref to alerts)....when in fact, they silence alerts, which may consequently silence notifications (and sometimes not). This is not the same as saying (and implying) silences only affect notifications, bc the fired alerts seen in (a) fired alert page and (b)alert rules pages are also silenced, which we havent mentioned and is a bit misleading.