### PR TITLE
Update pmm-admin.md

### DIFF
--- a/docs/details/commands/pmm-admin.md
+++ b/docs/details/commands/pmm-admin.md
@@ -609,6 +609,9 @@ In low resolution we collect metrics from collectors which could take some time:
     `--query-source=<query source>`
     : Source of SQL queries, one of: `pgstatements`, `pgstatmonitor`, `none` (default: `pgstatements`).
 
+    `--disable-queryexamples`
+    : Disable collection of query examples. Applicable only if `query-source` is set to `pgstatmonitor`.
+    
     `--environment=<environment>`
     : Environment name.
 


### PR DESCRIPTION
Added information on how to disable the collection of query examples for Postgres (e.g. if it's not desired to collect sensitive data into PMM).