### PR TITLE
Fix wrong runCommand

### DIFF
--- a/docs/setting-up/client/mongodb.md
+++ b/docs/setting-up/client/mongodb.md
@@ -102,10 +102,9 @@ To fetch advanced metrics, use the following to provide additional privileges to
 If the role `explainRole` already exists, then you can use the following command to provide additional privileges:
 
 ```json
- {
        db.runCommand(    {      
            grantPrivilegesToRole: "explainRole",      
-           privileges: [          { "resource" : { "db" : "", "collection" : "system.profile" }, "actions" : [ "indexStats", "dbStats", "collStats" ] } ] } )
+           privileges: [          { "resource" : { "db" : "", "collection" : "system.profile" }, "actions" : [ "indexStats", "dbStats", "collStats" ] } ] }        )
 ```
 
 ## Profiling


### PR DESCRIPTION
Removes non correct `{` at the beginning of the command.

There are also other formatting issues in the same file, but formatting issues only. This one was more serious as with that initial `{` the command will not work.

Awaiting preview build first, before asking review. Please do not merge yet.

Thanks,