### PR TITLE
Adding in links to supported versions of Kubernetes to DBaaS setup docs

### DIFF
--- a/docs/dbaas/setting-up.md
+++ b/docs/dbaas/setting-up.md
@@ -69,7 +69,12 @@ alias kubectl='minikube kubectl --'
 ## Create a Kubernetes cluster
 
 !!! note alert alert-primary ""
-    The DBaaS feature uses Kubernetes clusters to deploy database clusters. You must first create a Kubernetes cluster and then add it to PMM using `kubeconfig` to get a successful setup.
+    The DBaaS feature uses Kubernetes clusters to deploy database clusters. You must first create a Kubernetes cluster and then add it to PMM using `kubeconfig` to get a successful setup.  
+
+    Here are links to the current Kubernetes versions supported by DBaaS:
+    
+    - [Percona Server for MySQL](https://docs.percona.com/percona-operator-for-mysql/pxc/System-Requirements.html)
+    - [Percona Server for MongoDB](https://docs.percona.com/percona-operator-for-mongodb/System-Requirements.html)
 
 ### Minikube
 


### PR DESCRIPTION
When testing out DBaaS, it is helpful to have quick links in the k8s setup to the supported versions of k8s.  Currently, this is only available in the operator documentation.