### PR TITLE
RN_Techpreview_RHEL9_2_37_0

### DIFF
--- a/docs/release-notes/2.37.1.md
+++ b/docs/release-notes/2.37.1.md
@@ -34,4 +34,4 @@ Percona Monitoring and Management (PMM) is an open source database monitoring, m
 
 - An Enterprise Linux 9 (el9) version of PMM was released through oversight. This was intended to be a [technical preview](https://docs.percona.com/percona-monitoring-and-management/details/glossary.html#technical-preview). There are several known issues with this el9-based version. Thus, we do not recommend running it in production until the official GA announcement.
 
-    The images from the `percona` Docker repository have been removed. However, those who want to test them can locate them in the `perconalab` Docker repository.
+    The images from the `percona` Docker repository have been removed. However, those who want to test them can locate them in the `[perconalab](https://hub.docker.com/layers/perconalab/pmm-server/2.37.1-el9/images/sha256-da890362a138f40cad9cc2c0ffb66bdda0d307d438848a87ba619397754f4400?context=explore)` Docker repository.

--- a/docs/release-notes/2.37.1.md
+++ b/docs/release-notes/2.37.1.md
@@ -11,24 +11,27 @@ Percona Monitoring and Management (PMM) is an open source database monitoring, m
 
 ## Release Highlights
 
-We have identified and fixed CVE-2023-34409 in PMM 2.37.1:
+- We have identified and fixed CVE-2023-34409 in PMM 2.37.1:
 
-[PMM-12182](https://jira.percona.com/browse/PMM-12182): PMM authentication bypass vulnerability
+    [PMM-12182](https://jira.percona.com/browse/PMM-12182): PMM authentication bypass vulnerability
 
-**Workaround**
+    **Workaround**
 
-If you are unable to update PMM you can resolve this issue as follows:
+    If you are unable to update PMM you can resolve this issue as follows:
 
-1. Make changes to the NGINX configuration on the running PMM instance. To do so, create a Bash script with [the code from this script on GitHub](https://raw.githubusercontent.com/percona/pmm/main/scripts/authfix.sh). 
+    1. Make changes to the NGINX configuration on the running PMM instance. To do so, create a Bash script with [the code from this script on GitHub](https://raw.githubusercontent.com/percona/pmm/main/scripts/authfix.sh). 
 
-2. Apply the code using this `docker` command on a server running the PMM Docker container (as root or using sudo):
-    ```sh
-    docker exec -it pmm-server bash -c 'curl -fsSL https://raw.githubusercontent.com/percona/pmm/main/scripts/authfix.sh  | /bin/bash '
-    ```
-3. If you are running PMM via a virtual appliance (OVF or AMI), use SSH to shell into the PMM server and run this command:
-    ```sh
-    curl -fsSL https://raw.githubusercontent.com/percona/pmm/main/scripts/authfix.sh  | /bin/bash
-    ```
+    2. Apply the code using this `docker` command on a server running the PMM Docker container (as root or using sudo):
+        ```sh
+        docker exec -it pmm-server bash -c 'curl -fsSL https://raw.githubusercontent.com/percona/pmm/main/scripts/authfix.sh  | /bin/bash '
+        ```
+    3. If you are running PMM via a virtual appliance (OVF or AMI), use SSH to shell into the PMM server and run this command:
+        ```sh
+        curl -fsSL https://raw.githubusercontent.com/percona/pmm/main/scripts/authfix.sh  | /bin/bash
+        ```
 
-For more details see, [blogpost](https://percona.com/blog/pmm-authentication-bypass-vulnerability-fixed-in-2-37-1/).
+    For more details see, [blogpost](https://percona.com/blog/pmm-authentication-bypass-vulnerability-fixed-in-2-37-1/).
 
+- An Enterprise Linux 9 (el9) version of PMM was released through oversight. This was intended to be a [technical preview](https://docs.percona.com/percona-monitoring-and-management/details/glossary.html#technical-preview) as we prepared for the GA in  2.38.0. There are several known issues with this el9-based version. Thus, we do not recommend running it in production until the official GA announcement.
+
+    The images from the `percona` Docker repository have been removed. However, those who want to test them can locate them in the `perconalab` Docker repository.

--- a/docs/release-notes/2.37.1.md
+++ b/docs/release-notes/2.37.1.md
@@ -32,6 +32,6 @@ Percona Monitoring and Management (PMM) is an open source database monitoring, m
 
     For more details see, [blogpost](https://percona.com/blog/pmm-authentication-bypass-vulnerability-fixed-in-2-37-1/).
 
-- An Enterprise Linux 9 (el9) version of PMM was released through oversight. This was intended to be a [technical preview](https://docs.percona.com/percona-monitoring-and-management/details/glossary.html#technical-preview) as we prepared for the GA in  2.38.0. There are several known issues with this el9-based version. Thus, we do not recommend running it in production until the official GA announcement.
+- An Enterprise Linux 9 (el9) version of PMM was released through oversight. This was intended to be a [technical preview](https://docs.percona.com/percona-monitoring-and-management/details/glossary.html#technical-preview). There are several known issues with this el9-based version. Thus, we do not recommend running it in production until the official GA announcement.
 
     The images from the `percona` Docker repository have been removed. However, those who want to test them can locate them in the `perconalab` Docker repository.


### PR DESCRIPTION
Add RHEL9 migration as Technical Preview in the Release Notes, as this is confusing the users.