### PR TITLE
host changed on GRANT example

### DIFF
--- a/docs/setting-up/client/mysql.md
+++ b/docs/setting-up/client/mysql.md
@@ -33,7 +33,7 @@ It is good practice to use a non-superuser account to connect PMM Client to the 
 
 ```sql
 CREATE USER 'pmm'@'127.0.0.1' IDENTIFIED BY 'pass' WITH MAX_USER_CONNECTIONS 10;
-GRANT SELECT, PROCESS, REPLICATION CLIENT, RELOAD, BACKUP_ADMIN ON *.* TO 'pmm'@'localhost';
+GRANT SELECT, PROCESS, REPLICATION CLIENT, RELOAD, BACKUP_ADMIN ON *.* TO 'pmm'@'127.0.0.1';
 ```
 
 **On MySQL 5.7**


### PR DESCRIPTION
since the user is created as: 'pmm'@'127.0.0.1'
if one tries to run the GRANT example it will fail due mismatch on the host:
```
mysql> GRANT SELECT, PROCESS, REPLICATION CLIENT, RELOAD, BACKUP_ADMIN ON *.* TO 'pmm'@'localhost';
ERROR 1410 (42000): You are not allowed to create a user with GRANT
```

hence, changing it to "127.0.0.1"