### PR TITLE
v2.42.0 - Fix headings in release notes

### DIFF
--- a/docs/release-notes/2.42.0.md
+++ b/docs/release-notes/2.42.0.md
@@ -118,7 +118,7 @@ We encourage you to explore these experimental dashboards and provide feedback i
 
 ![!image](../_images/ReplSet_Dashboard_New.png)
 
-### Improvements
+## Improvements
 
 - [PMM-3303](https://perconadev.atlassian.net/browse/PMM-3303) - We've introduced an experimental PMM Health dashboard in the Experimental folder, offering detailed insights into PMM's health and performance by covering key components such as node health, Query Analytics, Grafana, VictoriaMetrics, ClickHouse, and PostgreSQL metrics.
 
@@ -138,7 +138,7 @@ We encourage you to explore these experimental dashboards and provide feedback i
 
 - [PMM-13119](https://perconadev.atlassian.net/browse/PMM-13119) - Improved the High Availability documentation Improved the High Availability documentation to clearly outline the available options for HA in PMM. For more information, see the [Set up PMM for HA topic](https://docs.percona.com/percona-monitoring-and-management/how-to/HA.html).
 
-### Fixed issues
+## Fixed issues
 
 - [PMM-12349](https://perconadev.atlassian.net/browse/PMM-12349) - Fixed an issue in the MongoDB RepSet Summary dashboard where incorrect data was displayed when a node in the replica set was down, ensuring that the dashboard accurately reflects the status and version information of the nodes even when they are unavailable.
 


### PR DESCRIPTION
**Before:**

<img width="191" alt="before" src="https://github.com/percona/pmm-doc/assets/31849787/68da35c9-1d26-4542-859e-2bfc07df453d">


**Now:**

<img width="131" alt="now" src="https://github.com/percona/pmm-doc/assets/31849787/f35d2a45-3d90-4295-b24f-9f406703cea6">
