### PR TITLE
Specify BINLOG MONITOR required for mariadb client setup

### DIFF
--- a/docs/setting-up/client/mysql.md
+++ b/docs/setting-up/client/mysql.md
@@ -46,7 +46,7 @@ It is good practice to use a non-superuser account to connect PMM Client to the 
 
     ```sql
     CREATE USER 'pmm'@'127.0.0.1' IDENTIFIED BY 'pass' WITH MAX_USER_CONNECTIONS 10;
-    GRANT SELECT, PROCESS, REPLICA MONITOR, RELOAD ON *.* TO 'pmm'@'127.0.0.1';
+    GRANT SELECT, PROCESS, REPLICA MONITOR, BINLOG MONITOR, RELOAD ON *.* TO 'pmm'@'127.0.0.1';
     ```
 ## Choose and configure a source
 


### PR DESCRIPTION
Issue was originally identified here: https://forums.percona.com/t/mariadb-pmm-client-commands-access-denied/32626

Following instructions, I noticed that pmm user was receiving many access denieds.

Looking at my previous mysqld exporter setup, I noticed that the instructions didn't specify to include the BINLOG MONITOR grant for the user.

Once I added BINLOG MONITOR, the number of access denieds dropped. 

It also made binlog related graphs start working

BINLOG MONITOR is required for SHOW BINLOG STATUS and SHOW BINARY LOGS

See https://mariadb.com/kb/en/grant/#binlog-monitor